### PR TITLE
Add wrapper functions for `getAllFilesFromDir` with named parameters

### DIFF
--- a/src/main/java/nf_core/nf/test/utils/Methods.java
+++ b/src/main/java/nf_core/nf/test/utils/Methods.java
@@ -12,10 +12,7 @@ import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.yaml.snakeyaml.Yaml;
 
@@ -46,6 +43,33 @@ public class Methods {
       }
     }
     return yamlData;
+  }
+
+  //wrapper functions for getAllFilesFromDir with default options
+  public static List getAllFilesFromDir(String path) throws IOException {
+    return getAllFilesFromDir(new LinkedHashMap<String, Object>(), path);
+  }
+
+  //wrapper functions for getAllFilesFromDir with named options
+  public static List getAllFilesFromDir(LinkedHashMap<String, Object> options, String path) throws IOException {
+    if (path == null || path.isEmpty()) {
+      throw new IllegalArgumentException("The 'path' parameter is required.");
+    }
+    //TODO: check if path exists
+
+    // Extract optional parameters from the map (use defaults if not provided)
+    Boolean includeDir = (Boolean) options.getOrDefault("includeDir", true);
+    List<String> ignoreGlobs = (List<String>) options.getOrDefault("ignore", new ArrayList<String>());
+    String ignoreFilePath = (String) options.get("ignoreFile");
+    Boolean relative = (Boolean) options.getOrDefault("relative", false);
+
+    List<File> files = getAllFilesFromDir(path, includeDir, ignoreGlobs, ignoreFilePath);
+
+    if (relative) {
+      return getRelativePath(files, path);
+    } else {
+      return files;
+    }
   }
 
   // Return all files in a directory and its sub-directories

--- a/tests/getAllFilesFromDir/main.nf.test
+++ b/tests/getAllFilesFromDir/main.nf.test
@@ -24,4 +24,28 @@ nextflow_pipeline {
           ).match()
         }
     }
+
+    test("getAllFilesFromDir with named params") {
+            when {
+                params {
+                    outdir = "$outputDir"
+                }
+            }
+
+            then {
+              //with default params and relative
+              println(getAllFilesFromDir(params.outdir))
+              println(getAllFilesFromDir(params.outdir, relative: true))
+              // Use getAllFilesFromDir() to get a list of all files and folders from the output directory, minus the timestamped files
+              def stable_name  = getAllFilesFromDir(params.outdir, ignore: ['pipeline_info/execution_*.{html,txt}'])
+              // works also with spaces.
+              def stable_content = getAllFilesFromDir params.outdir, includeDir: false, ignore: ['pipeline_info/execution_*.{html,txt}'], ignoreFile: 'tests/getAllFilesFromDir/.nftignore'
+              assert snapshot(
+                // Only snapshot name
+                stable_name*.name,
+                // Snapshot content
+                stable_content
+              ).match()
+            }
+        }
 }

--- a/tests/getAllFilesFromDir/main.nf.test.snap
+++ b/tests/getAllFilesFromDir/main.nf.test.snap
@@ -1,4 +1,22 @@
 {
+    "getAllFilesFromDir with named params": {
+        "content": [
+            [
+                "pipeline_info",
+                "stable",
+                "stable_content.txt",
+                "stable_name.txt"
+            ],
+            [
+                "stable_content.txt:md5,f6d73f703cda1c725ea78369a6c3a48d"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.07.0"
+        },
+        "timestamp": "2024-10-02T10:15:47.491035"
+    },
     "getAllFilesFromDir": {
         "content": [
             [


### PR DESCRIPTION
Hi all,

First of all, thank you for collecting all the nice snippets in one plugin. I really appreciate your effort! I believe having an independent plugin separate from the nf-test releases helps to incorporate changes more quickly.

I noticed that the Hackathon has its own nf-test plugin group. That’s wonderful to hear! 🚀

This PR adds a wrapper to the getAllFilesFromDir function and utilizes named parameters (a concept frequently used in Nextflow). I think this could serve as a good boilerplate to demonstrate how this approach can be implemented. It improves code readability and allows for the inclusion of additional optional parameters with default values, without making the method signature unreadable. 

Example:

```groovy
def stable_name  = getAllFilesFromDir(params.outdir, ignore: ['pipeline_info/execution_*.{html,txt}'])
def stable_content = getAllFilesFromDir(params.outdir, includeDir: false, ignore: ['pipeline_info/execution_*.{html,txt}'], ignoreFile: 'tests/getAllFilesFromDir/.nftignore')
assert snapshot(
  // Only snapshot name
  stable_name*.name,
  // Snapshot content
  stable_content
).match()

//with default params and relative
println(getAllFilesFromDir(params.outdir))
println(getAllFilesFromDir(params.outdir, relative: true))
```

I also included a relative option to combine it with `getRelativePath(..)`.

Hope this helps and thanks guys! 🚀🙏