### PR TITLE
Fix rendering of cloning code blocks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,17 +23,17 @@ To use the development version, please do the following steps:
 
 - Clone the [nft-utils repository](https://github.com/nf-core/nft-utils)
 
-=== "HTTPS"
+### HTTPS
 
-    ```bash
-    git clone git@github.com:nf-core/nft-utils.git
-    ```
+  ```bash
+  git clone git@github.com:nf-core/nft-utils.git
+  ```
 
-=== "SSH"
+### SSH
 
-    ```bash
-    git clone https://github.com/nf-core/nft-utils.git
-    ```
+  ```bash
+  git clone https://github.com/nf-core/nft-utils.git
+  ```
 
 - Run the build script
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,13 +23,13 @@ To use the development version, please do the following steps:
 
 - Clone the [nft-utils repository](https://github.com/nf-core/nft-utils)
 
-### HTTPS
+### SSH
 
   ```bash
   git clone git@github.com:nf-core/nft-utils.git
   ```
 
-### SSH
+### HTTPS
 
   ```bash
   git clone https://github.com/nf-core/nft-utils.git


### PR DESCRIPTION
Fixed the rendering of the two code blocks for cloning the repo.

Old rendering (at least on my end):
<img width="836" alt="Screenshot 2025-06-20 at 10 44 50" src="https://github.com/user-attachments/assets/e6d8a3ba-621e-421b-abd6-871d7e2d8d26" />
