### PR TITLE
nfcoreLibraryLinker: exit gracefully when directories don't exist

### DIFF
--- a/src/main/java/nf_core/nf/test/utils/NfCoreUtils.java
+++ b/src/main/java/nf_core/nf/test/utils/NfCoreUtils.java
@@ -139,14 +139,20 @@ public class NfCoreUtils {
       File libModulesDir = new File(libDir + "/modules");
       File destModulesDir = new File(modulesDir);
 
+      // Capitalise mode string for error messages
+      String Mode = mode.substring(0, 1).toUpperCase() + mode.substring(1);
+      
       if (!libModulesDir.exists() || !libModulesDir.isDirectory()) {
-        throw new RuntimeException(
-          "Error: Library modules directory does not exist: " + libModulesDir.getAbsolutePath()
-        );
+        String Mode = mode.substring(0, 1).toUpperCase() + mode.substring(1);
+        System.err.println("Warning: Library modules directory does not exist: " + libModulesDir.getAbsolutePath());
+        System.err.println(Mode + "ing halted!");
+        return;
       }
 
       if (!destModulesDir.exists()) {
-        throw new RuntimeException("Error: modules directory does not exist: " + libModulesDir.getAbsolutePath());
+        System.err.println("Warning: Modules directory does not exist: " + destModulesDir.getAbsolutePath());
+        System.err.println(Mode + "ing halted!");
+        return;
       }
 
       // Starting at the organisation-dir (e.g. nf-core) - link it if it doesn't exist, otherwise


### PR DESCRIPTION
Presently, the nfcoreLibraryLinker function throws an exception if either the temporary nf-core library or the target modules directory do not exist.

This causes some issues with tests that call this function in the `cleanup {}` block of an nf-test, when nf-test is executed in `--dry-run` mode, as the dry-run mode tries to execute the cleanup block (but not the setup block): https://github.com/askimed/nf-test/pull/330

See e.g. https://github.com/sanger-tol/nf-core-modules/blob/main/modules/sanger-tol/hiccramalign/minimap2align/tests/main.nf.test for an example of a test that fails.

This PR modifies the nfcoreLibraryLinker function to print a warning and exit gracefully when either directory doesn't exist (because set-up hasn't run). This is safe because if the directories don't exist, nothing should have been linked to or from them in any case. 

This will temporarily side-step the problem we are having until it can be fixed upstream in nf-test.