### PR TITLE
Add `ignoreKeys` for `sanitizeOutput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.0dev
+
+- Add `ignoreKeys` for `sanitizeOutput` and key presence check. Add jupiter test.
+
 ## 1.0.0
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.1.0dev
 
+- Fix `unstableKeys` usage for `sanitizeOutput` when a folder is passed.
 - Add `ignoreKeys` for `sanitizeOutput` and key presence check. Add jupiter test.
 
 ## 1.0.0

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -34,11 +34,33 @@
       </plugin>
     </plugins>
   </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.12.2</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>junit-jupiter-api</artifactId>
+          <groupId>org.junit.jupiter</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>junit-jupiter-params</artifactId>
+          <groupId>org.junit.jupiter</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>junit-jupiter-engine</artifactId>
+          <groupId>org.junit.jupiter</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
   <properties>
     <maven.compiler.release>${java.version}</maven.compiler.release>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
     <java.version>11</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
-    <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <htsjdk.version>3.0.5</htsjdk.version>
     <additionalparam>-Xdoclint:none</additionalparam>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -704,6 +704,14 @@ then {
 }
 ```
 
+- `ignoreKeys`: A list of keys to exclude from the snapshot. This is useful for output entries where the file name may vary between runs.
+
+```groovy
+then {
+  assert snapshot(sanitizeOutput(process.out, ignoreKeys:["log"])).match()
+}
+```
+
 ### `curlAndExtract()` - Download and extract an archive
 
 The `curlAndExtract()` function is used to download an archive

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
 			<artifactId>snakeyaml</artifactId>
 			<version>2.3</version>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.12.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/nf_core/nf/test/utils/OutputSanitizer.java
+++ b/src/main/java/nf_core/nf/test/utils/OutputSanitizer.java
@@ -11,6 +11,19 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 public class OutputSanitizer {
+  static void validateUnstableKeys(
+    List<String> unstableKeys,
+    Map<String, Object> channel) {
+
+    for (String unstableKey : unstableKeys) {
+      if (!channel.containsKey(unstableKey)) {
+        throw new RuntimeException(
+          "Unstable key '" + unstableKey +
+          "' not present in channel"
+        );
+      }
+    }
+  }
   public static TreeMap<String,Object> sanitizeOutput(HashMap<String,Object> options, TreeMap<String,Object> channel) {
     String className = channel.getClass().getName();
     // Can't do valid type checking here because the Channels type is not exposed from nf-test
@@ -19,7 +32,11 @@ public class OutputSanitizer {
     }
 
     // Fetch options
-    ArrayList<String> unstableKeys = (ArrayList<String>) options.getOrDefault("unstableKeys", new java.util.ArrayList<String>());
+    List<String> unstableKeys = (List<String>) options.getOrDefault("unstableKeys", List.of());
+    validateUnstableKeys(unstableKeys, channel);
+
+    List<String> ignoreKeys = (List<String>) options.getOrDefault("ignoreKeys", List.of());
+    validateUnstableKeys(ignoreKeys, channel);
 
     TreeMap<String,Object> output = new TreeMap<String,Object>();
     Integer channelSize = (Integer) channel.size();
@@ -30,6 +47,10 @@ public class OutputSanitizer {
         // Skip numeric keys if there is more than one entry in the channel
         continue;
       }
+      if (ignoreKeys.contains(key)) {
+        continue;
+      }
+
       if(unstableKeys.contains(key)) {
         output.put(key, fixUnstable(value));
       } else {

--- a/src/test/java/nf_core/nf/test/utils/OutputSanitizerTest.java
+++ b/src/test/java/nf_core/nf/test/utils/OutputSanitizerTest.java
@@ -1,0 +1,91 @@
+package nf_core.nf.test.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OutputSanitizerTest {
+
+    @Test
+    void shouldAcceptUnstableKeyPresentInChannel() {
+        Map<String, Object> channel = Map.of(
+            "foo", "some-value",
+            "bar", "another-value"
+        );
+        assertDoesNotThrow(() ->
+            OutputSanitizer.validateUnstableKeys(
+                List.of("foo"),
+                channel
+            )
+        );
+    }
+
+    @Test
+    void shouldRejectUnstableKeyNotPresentInChannel() {
+        Map<String, Object> channel = Map.of(
+            "foo", "some-value",
+            "bar", "another-value"
+        );
+        RuntimeException exception = assertThrows(
+            RuntimeException.class,
+            () -> OutputSanitizer.validateUnstableKeys(
+                List.of("baz"),
+                channel
+            )
+        );
+        assertEquals(
+            "Unstable key 'baz' not present in channel",
+            exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldAcceptMultipleValidUnstableKeys() {
+        Map<String, Object> channel = Map.of(
+            "foo", "value1",
+            "bar", "value2",
+            "baz", "value3"
+        );
+        assertDoesNotThrow(() ->
+            OutputSanitizer.validateUnstableKeys(
+                List.of("foo", "bar"),
+                channel
+            )
+        );
+    }
+
+    @Test
+    void shouldRejectWhenOneUnstableKeyIsMissing() {
+        Map<String, Object> channel = Map.of(
+            "foo", "value1",
+            "bar", "value2"
+        );
+        RuntimeException exception = assertThrows(
+            RuntimeException.class,
+            () -> OutputSanitizer.validateUnstableKeys(
+                List.of("foo", "missing"),
+                channel
+            )
+        );
+        assertEquals(
+            "Unstable key 'missing' not present in channel",
+            exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldAcceptEmptyUnstableKeys() {
+        Map<String, Object> channel = Map.of(
+            "foo", "value1"
+        );
+        assertDoesNotThrow(() ->
+            OutputSanitizer.validateUnstableKeys(
+                List.of(),
+                channel
+            )
+        );
+    }
+}

--- a/tests/sanitizeOutput/main.nf.test
+++ b/tests/sanitizeOutput/main.nf.test
@@ -20,4 +20,18 @@ nextflow_process {
             assert snapshot(sanitizeOutput(process.out, unstableKeys:["zip"])).match()
         }
     }
+
+    test("Default sanitize output - with ignoreKeys zip + html") {
+        when {
+          process {
+            """
+            input[0] = [id:"test"]
+            """
+          }
+        }
+        then {
+            assert process.success
+            assert snapshot(sanitizeOutput(process.out, ignoreKeys:["zip", "html"])).match()
+        }
+    }
 }

--- a/tests/sanitizeOutput/main.nf.test.snap
+++ b/tests/sanitizeOutput/main.nf.test.snap
@@ -1,21 +1,4 @@
 {
-    "Default sanitize output - with ignoreKeys zip + html": {
-        "content": [
-            {
-                "id": [
-                    "test"
-                ],
-                "zip_only": [
-                    "test_fastqc.zip:md5,b14838a8cfd436e61fbf159d7255cc59"
-                ]
-            }
-        ],
-        "timestamp": "2026-08-10T22:36:08.810863842",
-        "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "26.04.6"
-        }
-    },
     "Default sanitize output - with unstableKeys": {
         "content": [
             {
@@ -105,6 +88,37 @@
             }
         ],
         "timestamp": "2026-08-10T20:18:28.061852829",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "Default sanitize output - with ignoreKeys zip + html": {
+        "content": [
+            {
+                "folder": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            [
+                                "test3.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                            ],
+                            "test1.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test2.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "id": [
+                    "test"
+                ],
+                "zip_only": [
+                    "test_fastqc.zip:md5,b14838a8cfd436e61fbf159d7255cc59"
+                ]
+            }
+        ],
+        "timestamp": "2026-08-11T09:54:50.525356716",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/sanitizeOutput/main.nf.test.snap
+++ b/tests/sanitizeOutput/main.nf.test.snap
@@ -1,4 +1,21 @@
 {
+    "Default sanitize output - with ignoreKeys zip + html": {
+        "content": [
+            {
+                "id": [
+                    "test"
+                ],
+                "zip_only": [
+                    "test_fastqc.zip:md5,b14838a8cfd436e61fbf159d7255cc59"
+                ]
+            }
+        ],
+        "timestamp": "2026-08-10T22:36:08.810863842",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
     "Default sanitize output": {
         "content": [
             {
@@ -26,10 +43,10 @@
                 ]
             }
         ],
+        "timestamp": "2025-09-11T14:51:48.072281016",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-09-11T14:51:48.072281016"
+        }
     }
 }


### PR DESCRIPTION
This PR add the `ignoreKeys` option for `sanitizeOutput()` when you want to exclude an output from the snapshot completely.

Should partially answer #52