### PR TITLE
Add patterns usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `unstableKeys` usage for `sanitizeOutput` when a folder is passed.
 - Add `ignoreKeys` for `sanitizeOutput` and key presence check. Add jupiter test.
 - Add `readsMD5Keys` and `variantsMD5Keys` for `sanitizeOutput` so that md5 is the one from the reads and from the variants.
+- Add `unstablePattern` and `ignorePattern` to `sanitizeOutput` for more fine grained parsing.
 
 ## 1.0.0
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -712,6 +712,14 @@ then {
 }
 ```
 
+- `ignoreKeys`: A list of keys to exclude from the snapshot. This is useful for output entries where the file name may vary between runs.
+
+```groovy
+then {
+  assert snapshot(sanitizeOutput(process.out, ignoreKeys:["log"])).match()
+}
+```
+
 - `readsMD5Keys`: A list of keys containing genomic alignment files. MD5 sum of files with `<.bam,.sam,.cram>` extension will be replaced by an md5 computed only on the reads (i.e. equivalent of `bam(...).getReadsMD5()`) using the [`nft-bam`](https://nvnieuwk.github.io/nft-bam/dev/) plugin.
   The latter should be added in the `plugins {}` section of the `nf-test.config`.
   For `.cram` files, you also need to pass the reference genome `.fasta` (the `.fai` is automatically detected by `nft-bam`).
@@ -729,6 +737,16 @@ then {
 ```groovy
 then {
   assert snapshot(sanitizeOutput(process.out, variantsMD5Keys:["vcf"])).match()
+}
+```
+
+- `unstablePattern` and `ignorePattern`: Lists of regex pattern that will be matched against each value of the channel. If a match is found for a given file, `unstablePattern` will remove the md5sum, and `ignorePattern` will completely ignore the file from the snapshot.
+  Beware that patterns across `unstablePattern` and `ignorePattern` should be mutually exclusive.
+  Channel key provided by `unstableKeys`, `ignoreKeys`, `readsMD5Keys` and `variantsMD5Keys` will not be matched agains these pattern.
+
+```groovy
+then {
+  assert snapshot(sanitizeOutput(process.out, unstablePattern:[".*\\.log$"], ignorePattern:["VERSION\\_.*$"])).match()
 }
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -712,14 +712,6 @@ then {
 }
 ```
 
-- `ignoreKeys`: A list of keys to exclude from the snapshot. This is useful for output entries where the file name may vary between runs.
-
-```groovy
-then {
-  assert snapshot(sanitizeOutput(process.out, ignoreKeys:["log"])).match()
-}
-```
-
 - `readsMD5Keys`: A list of keys containing genomic alignment files. MD5 sum of files with `<.bam,.sam,.cram>` extension will be replaced by an md5 computed only on the reads (i.e. equivalent of `bam(...).getReadsMD5()`) using the [`nft-bam`](https://nvnieuwk.github.io/nft-bam/dev/) plugin.
   The latter should be added in the `plugins {}` section of the `nf-test.config`.
   For `.cram` files, you also need to pass the reference genome `.fasta` (the `.fai` is automatically detected by `nft-bam`).

--- a/src/main/java/nf_core/nf/test/utils/OutputSanitizer.java
+++ b/src/main/java/nf_core/nf/test/utils/OutputSanitizer.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.Vector;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.function.Function;
@@ -86,6 +85,12 @@ public final class OutputSanitizer {
     List<String> ignoreKeys =
       (List<String>) options.getOrDefault("ignoreKeys", List.of());
 
+    List<String> unstablePattern =
+      (List<String>) options.getOrDefault("unstablePattern", List.of());
+
+    List<String> ignorePattern =
+      (List<String>) options.getOrDefault("ignorePattern", List.of());
+
     List<String> readsMD5Keys =
       (List<String>) options.getOrDefault("readsMD5Keys", List.of());
 
@@ -138,13 +143,29 @@ public final class OutputSanitizer {
       } else if (variantsMD5Keys.contains(key)) {
         output.put(key, VcfUtils.vcfMD5(value));
       } else {
-        output.put(key, value);
+        output.put(key, checkPattern(value, unstablePattern, ignorePattern));
       }
     }
     return output;
   }
 
-  static Object recursiveParse(final Object value, final Function<String, Object> applyFct) {
+  /**
+   * Recursively parses a value and applies the provided function
+   * to string values.
+   *
+   * Directories are traversed recursively, lists are parsed element
+   * by element, and maps are parsed value by value.
+   * Values that resolve to the {@code IGNORE} marker are excluded
+   * from the resulting collections.
+   *
+   * @param value The value to parse.
+   * @param applyFct The function to apply to string values.
+   * @return The recursively parsed value.
+  */
+  private static final Object IGNORE = new Object();
+  static Object recursiveParse(
+      final Object value,
+      final Function<String, Object> applyFct) {
     if (value instanceof String) {
       String strValue = (String) value;
       java.nio.file.Path path = Paths.get(strValue);
@@ -153,9 +174,12 @@ public final class OutputSanitizer {
         try {
           Files.list(path)
             .sorted()
-            .forEach(child -> fixedList.add(
-              recursiveParse(child.toString(), applyFct)
-            ));
+            .forEach(child -> {
+              Object parsed = recursiveParse(child.toString(), applyFct);
+              if (parsed != IGNORE) {
+                fixedList.add(parsed);
+              }
+            });
 
           return fixedList;
         } catch (java.io.IOException e) {
@@ -163,21 +187,24 @@ public final class OutputSanitizer {
         }
       }
       return applyFct.apply(strValue);
-    } else if (value instanceof ArrayList || value instanceof Vector) {
+    } else if (value instanceof List) {
       List<?> listValue = (List<?>) value;
       ArrayList<Object> fixedList = new ArrayList<>();
       for (Object item : listValue) {
-        fixedList.add(recursiveParse(item, applyFct));
+        Object parsed = recursiveParse(item, applyFct);
+        if (parsed != IGNORE) {
+          fixedList.add(parsed);
+        }
       }
       return fixedList;
     } else if (value instanceof Map) {
       Map<?, ?> mapValue = (Map<?, ?>) value;
       Map<Object, Object> fixedMap = new TreeMap<>();
       for (Map.Entry<?, ?> entry : mapValue.entrySet()) {
-        fixedMap.put(
-          entry.getKey(),
-          recursiveParse(entry.getValue(), applyFct)
-        );
+        Object parsed = recursiveParse(entry.getValue(), applyFct);
+        if (parsed != IGNORE) {
+          fixedMap.put(entry.getKey(), parsed);
+        }
       }
       return fixedMap;
     } else {
@@ -185,11 +212,58 @@ public final class OutputSanitizer {
     }
   }
 
+  /**
+   * Recursively sanitizes unstable file paths by replacing existing paths
+   * with their file names.
+   *
+   * @param value The value to sanitize.
+   * @return The sanitized value with file paths reduced to file names.
+   */
   private static Object fixUnstable(final Object value) {
     return recursiveParse(value, strValue -> {
       java.nio.file.Path path = Paths.get(strValue);
       if (Files.exists(path)) {
         return path.getFileName().toString();
+      }
+      return strValue;
+    });
+  }
+
+  /**
+   * Recursively applies the configured unstable and ignore patterns to a value.
+   *
+   * Values matching {@code ignorePattern} are excluded, while values matching
+   * {@code unstablePattern} have their paths reduced to file names. A value
+   * matching both patterns causes a {@link RuntimeException}.
+   *
+   * @param value The value to sanitize.
+   * @param unstablePattern The regular expression patterns identifying unstable
+   * values.
+   * @param ignorePattern The regular expression patterns identifying values to
+   * ignore.
+   * @return The sanitized value.
+   */
+  static Object checkPattern(
+    final Object value,
+    final List<String> unstablePattern,
+    final List<String> ignorePattern) {
+
+    return recursiveParse(value, strValue -> {
+      boolean matchIgnore = ignorePattern.stream()
+        .anyMatch(strValue::matches);
+      boolean matchUnstable = unstablePattern.stream()
+        .anyMatch(strValue::matches);
+      if (matchIgnore && matchUnstable) {
+        throw new RuntimeException(
+          "Value '" + strValue
+          + "' matches both ignorePattern and unstablePattern"
+        );
+      }
+      if (matchIgnore) {
+        return IGNORE;
+      }
+      if (matchUnstable) {
+        return Paths.get(strValue).getFileName().toString();
       }
       return strValue;
     });

--- a/src/test/java/nf_core/nf/test/utils/OutputSanitizerTest.java
+++ b/src/test/java/nf_core/nf/test/utils/OutputSanitizerTest.java
@@ -2,6 +2,8 @@ package nf_core.nf.test.utils;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -117,4 +119,53 @@ class OutputSanitizerTest {
             exception.getMessage()
         );
     }
+
+    @Test
+    void checkPatternFailMatchBothIgnoreAndUnstable() {
+        RuntimeException exception = assertThrows(
+            RuntimeException.class,
+            () -> OutputSanitizer.checkPattern(
+                List.of("MyFile.bam", "MyFile.vcf"),
+                List.of(".*\\.bam$", ".*\\.vcf$"),
+                List.of(".*\\.vcf$")
+            )
+        );
+
+        assertEquals(
+            "Value 'MyFile.vcf' matches both ignorePattern and unstablePattern",
+            exception.getMessage()
+        );
+    }
+
+  @Test
+  void checkPatternShouldIgnoreTxtFileAndSimplifyBamInList() {
+    Object outputCheck = OutputSanitizer.checkPattern(
+      List.of(
+        "/tmp/some.directory/example.bam",
+        "/tmp/some.directory/example.txt"
+      ),
+      List.of(".*\\.bam$"),
+      List.of(".*\\.txt$")
+    );
+    assertEquals(
+      outputCheck,
+      List.of("example.bam")
+    );
+  }
+
+  @Test
+  void checkPatternShouldIgnoreTxtFileAndSimplifyBamInMap() {
+    Object outputCheck = OutputSanitizer.checkPattern(
+      Map.of(
+        "bam", "/tmp/some.directory/example.bam",
+        "txt", "/tmp/some.directory/example.txt"
+      ),
+      List.of(".*\\.bam$"),
+      List.of(".*\\.txt$")
+    );
+    assertEquals(
+      outputCheck,
+      Map.of("bam", "example.bam")
+    );
+  }
 }

--- a/tests/sanitizeOutput/modules/local/test/tests/main.nf.test
+++ b/tests/sanitizeOutput/modules/local/test/tests/main.nf.test
@@ -46,4 +46,34 @@ nextflow_process {
             assert snapshot(sanitizeOutput(process.out, ignoreKeys:["zip", "html"])).match()
         }
     }
+
+    test("Default sanitize output - with ignorePattern test1") {
+        tag "test2"
+        when {
+          process {
+            """
+            input[0] = [id:"test"]
+            """
+          }
+        }
+        then {
+            assert process.success
+            assert snapshot(sanitizeOutput(process.out, ignorePattern:[".*test1.*"])).match()
+        }
+    }
+
+    test("Default sanitize output - with unstablePattern test1") {
+        tag "test2"
+        when {
+          process {
+            """
+            input[0] = [id:"test"]
+            """
+          }
+        }
+        then {
+            assert process.success
+            assert snapshot(sanitizeOutput(process.out, unstablePattern:[".*test1.*"])).match()
+        }
+    }
 }

--- a/tests/sanitizeOutput/modules/local/test/tests/main.nf.test
+++ b/tests/sanitizeOutput/modules/local/test/tests/main.nf.test
@@ -48,7 +48,6 @@ nextflow_process {
     }
 
     test("Default sanitize output - with ignorePattern test1") {
-        tag "test2"
         when {
           process {
             """
@@ -63,7 +62,6 @@ nextflow_process {
     }
 
     test("Default sanitize output - with unstablePattern test1") {
-        tag "test2"
         when {
           process {
             """

--- a/tests/sanitizeOutput/modules/local/test/tests/main.nf.test.snap
+++ b/tests/sanitizeOutput/modules/local/test/tests/main.nf.test.snap
@@ -1,4 +1,97 @@
 {
+    "Default sanitize output - with ignorePattern test1": {
+        "content": [
+            {
+                "folder": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            [
+                                "test3.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                            ],
+                            "test2.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_fastqc.html:md5,24854f9d4c2bc9e908174cabefb1cf07"
+                    ]
+                ],
+                "id": [
+                    "test"
+                ],
+                "zip": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_fastqc.zip:md5,b14838a8cfd436e61fbf159d7255cc59"
+                    ]
+                ],
+                "zip_only": [
+                    "test_fastqc.zip:md5,b14838a8cfd436e61fbf159d7255cc59"
+                ]
+            }
+        ],
+        "timestamp": "2026-08-12T19:40:24.255919763",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "Default sanitize output - with unstablePattern test1": {
+        "content": [
+            {
+                "folder": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            [
+                                "test3.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                            ],
+                            "test1.txt",
+                            "test2.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_fastqc.html:md5,24854f9d4c2bc9e908174cabefb1cf07"
+                    ]
+                ],
+                "id": [
+                    "test"
+                ],
+                "zip": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_fastqc.zip:md5,b14838a8cfd436e61fbf159d7255cc59"
+                    ]
+                ],
+                "zip_only": [
+                    "test_fastqc.zip:md5,b14838a8cfd436e61fbf159d7255cc59"
+                ]
+            }
+        ],
+        "timestamp": "2026-08-12T19:30:34.291772351",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
     "Default sanitize output - with unstableKeys": {
         "content": [
             {


### PR DESCRIPTION
This PR add:
- `ignorePattern` when you want to ignore a particular file from a folder but still snapshot the rest
- `unstablePattern` when you want to remove the md5sum computation for a given set of file (e.g. `.log`)