### PR TITLE
refactor: decompose Methods.java into focused utility classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,7 +174,7 @@ First release of nft-utils 🍏🚀
 - [#1](https://github.com/nf-core/nft-utils/pull/1) Initial repo setup (@adamrtalbot).
 - [#6](https://github.com/nf-core/nft-utils/pull/6) Add `removeNextflowVersion` function (@maxulysse).
 - [#7](https://github.com/nf-core/nft-utils/pull/7) Add `getAllFilesFromDir` function (@maxulysse).
-- [#9](https://github.com/nf-core/nft-utils/pull/9), [#11](https://github.com/nf-core/nft-utils/pull/11), [#12](https://github.com/nf-core/nft-utils/pull/12), [#13](https://github.com/nf-core/nft-utils/pull/13) Add documentation (@maxulysse, @adamrtalbot).
+- [#9](https://github.com/nf-core/nft-utils/pull/9), [#11](https://github.com/nf-core/nft-utils/pull/11), [#12](https://github.com/nf-core/nft-utils/pull/12) Add documentation (@maxulysse, @adamrtalbot).
 
 ### New Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,108 +3,133 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.2.0
-
-### Fixed
-
-- Fix empty value usage in `sanitizeOutput()`. See [#84](https://github.com/nf-core/nft-utils/issues/84)
+## Unreleased
 
 ### Added
 
-- Add `csvMD5Keys` for `sanitizeOutput` to hash normalized CSV content
+- [#90](https://github.com/nf-core/nft-utils/pull/90) Implement `additionalPatterns` parameter in `filterNextflowOutput` (@maxulysse).
 
 ### Changed
 
-- Improve documentation: clean up prose, add feature list to README, standardize CHANGELOG categories
-
-## [1.1.1]
+- [#90](https://github.com/nf-core/nft-utils/pull/90) Refactor `Methods.java` into separate utility classes (`HashUtils`, `YamlUtils`, `ArchiveDownloader`, `FileTraversalUtils`, `NextflowOutputFilter`) (@maxulysse).
 
 ### Fixed
 
-- Use `unstablePatterns` and `ignorePatterns` instead of `unstablePattern` and `ignorePattern`
+- [#90](https://github.com/nf-core/nft-utils/pull/90) `ArchiveDownloader` and `NfCoreUtils.installModule` now throw `IOException` on failure (@maxulysse).
+- [#90](https://github.com/nf-core/nft-utils/pull/90) Fix raw types in public API signatures (@maxulysse).
 
-## [1.1.0]
+## 1.2.0
 
 ### Added
 
-- Add `ignoreKeys` for `sanitizeOutput` and key presence check
-- Add `readsMD5Keys` and `variantsMD5Keys` for `sanitizeOutput` to hash reads and variants separately
-- Add `unstablePattern` and `ignorePattern` to `sanitizeOutput` for glob-based filtering
+- [#86](https://github.com/nf-core/nft-utils/pull/86) Add `csvMD5Keys` for `sanitizeOutput` to hash normalized CSV content (@LouisLeNezet).
 
 ### Fixed
 
-- Fix `unstableKeys` usage for `sanitizeOutput` when a folder is passed
-- Fix linting with `mvn checkstyle:check` and restructure folders
-- Use glob patterns instead of regex for `ignorePattern` and `unstablePattern`
-- Update GitHub Actions to use environment and cache; add linting and bug checks to Maven lifecycle
-- Fix `nfcoreInitialise()` for nf-core tools 4.1.0 compatibility (requires `conf/` directory)
+- [#85](https://github.com/nf-core/nft-utils/pull/85) Fix empty value usage in `sanitizeOutput()`. See [#84](https://github.com/nf-core/nft-utils/issues/84) (@LouisLeNezet).
 
-## [1.0.0]
+### Changed
 
-### Added
+- [#88](https://github.com/nf-core/nft-utils/pull/88) Clean up documentation prose, add feature list to README, standardize CHANGELOG (@maxulysse).
 
-- Add `getAllFilesFromPath()` to retrieve files from local or S3 paths with `include`/`ignore` glob patterns, `includeDir`, and `noSignRequest` for S3
-
-## [0.0.9]
-
-### Added
-
-- `nfcoreInstall()` now tracks installed modules via state files, skipping already installed modules
-- Add `filterNextflowOutput()` to clean Nextflow stdout/stderr with `include`/`ignore` filters and `keepAnsi` option
-
-## [0.0.8]
-
-### Added
-
-- Add `curlAndExtract()` to download and extract `tar` and `zip` files during nf-test setup
-
-## [0.0.7]
-
-### Added
-
-- Add `OutputSanitizer` class with `sanitizeOutput()` to process and clean output channels, supporting `unstableKeys` for unstable file outputs (@nvnieuwk)
+## 1.1.1
 
 ### Fixed
 
-- `nfcoreLibraryLinker`: exit gracefully when directories don't exist (@prototaxites)
+- [#83](https://github.com/nf-core/nft-utils/pull/83) Use `unstablePatterns` and `ignorePatterns` instead of `unstablePattern` and `ignorePattern` (@LouisLeNezet).
 
-## [0.0.6]
-
-### Added
-
-- Add stdout and stderr helper functions for better snapshots (@maxulysse)
-
-### Fixed
-
-- Improve documentation (@maxulysse)
-
-## [0.0.5]
+## 1.1.0
 
 ### Added
 
-- Add functions for managing dependencies on nf-core modules (@prototaxites)
+- [#75](https://github.com/nf-core/nft-utils/pull/75) Add `ignoreKeys` for `sanitizeOutput` and key presence check (@LouisLeNezet).
+- [#76](https://github.com/nf-core/nft-utils/pull/76) Add `readsMD5Keys` and `variantsMD5Keys` for `sanitizeOutput` to hash reads and variants separately (@LouisLeNezet).
+- [#77](https://github.com/nf-core/nft-utils/pull/77) Add `unstablePattern` and `ignorePattern` to `sanitizeOutput` for glob-based filtering (@LouisLeNezet).
 
 ### Fixed
 
-- Fix rendering of cloning code blocks (@TCLamnidis)
+- [#74](https://github.com/nf-core/nft-utils/pull/74) Fix `unstableKeys` usage for `sanitizeOutput` when a folder is passed (@LouisLeNezet).
+- [#78](https://github.com/nf-core/nft-utils/pull/78) Fix linting with `mvn checkstyle:check` and restructure folders (@LouisLeNezet).
+- [#79](https://github.com/nf-core/nft-utils/pull/79) Use glob patterns instead of regex for `ignorePattern` and `unstablePattern` (@LouisLeNezet).
+- [#80](https://github.com/nf-core/nft-utils/pull/80) Update GitHub Actions to use environment and cache; add linting and bug checks to Maven lifecycle (@LouisLeNezet).
+- [#81](https://github.com/nf-core/nft-utils/pull/81) Fix `nfcoreInitialise()` for nf-core tools 4.1.0 compatibility (requires `conf/` directory) (@JimDownie).
+
+### New Contributors
+
+- @LouisLeNezet
+
+## 1.0.0
+
+### Added
+
+- [#69](https://github.com/nf-core/nft-utils/pull/69) Add `getAllFilesFromPath()` to retrieve files from local or S3 paths with `include`/`ignore` glob patterns, `includeDir`, and `noSignRequest` for S3 (@maxulysse).
+
+## 0.0.9
+
+### Added
+
+- [#61](https://github.com/nf-core/nft-utils/pull/61) `nfcoreInstall()` now tracks installed modules via state files, skipping already installed modules (@JimDownie).
+- [#62](https://github.com/nf-core/nft-utils/pull/62) Add `getAllFilesFromChannel()` to extract absolute file paths from Nextflow channel output (@maxulysse).
+- [#63](https://github.com/nf-core/nft-utils/pull/63) Add `filterNextflowOutput()` to clean Nextflow stdout/stderr with `include`/`ignore` filters and `keepAnsi` option (@maxulysse).
+
+## 0.0.8
+
+### Added
+
+- [#55](https://github.com/nf-core/nft-utils/pull/55) Add `curlAndExtract()` to download and extract `tar` and `zip` files during nf-test setup (@muffato).
+
+### New Contributors
+
+- @muffato
+
+## 0.0.7
+
+### Added
+
+- [#48](https://github.com/nf-core/nft-utils/pull/48) Add `OutputSanitizer` class with `sanitizeOutput()` to process and clean output channels, supporting `unstableKeys` for unstable file paths (@nvnieuwk).
+
+### Fixed
+
+- [#50](https://github.com/nf-core/nft-utils/pull/50) `nfcoreLibraryLinker`: exit gracefully when directories don't exist (@prototaxites).
+
+## 0.0.6
+
+### Added
+
+- [#45](https://github.com/nf-core/nft-utils/pull/45) Add stdout and stderr helper functions for better snapshots (@maxulysse).
+
+### Fixed
+
+- [#44](https://github.com/nf-core/nft-utils/pull/44) Improve documentation (@maxulysse).
+
+## 0.0.5
+
+### Added
+
+- [#42](https://github.com/nf-core/nft-utils/pull/42) Add functions for managing dependencies on nf-core modules (@prototaxites).
+
+### Fixed
+
+- [#41](https://github.com/nf-core/nft-utils/pull/41) Fix rendering of cloning code blocks (@TCLamnidis).
 
 ### New Contributors
 
 - @prototaxites
 - @TCLamnidis
 
-## [0.0.4]
+## 0.0.4
 
 ### Added
 
-- Add `listToMD5` (@nvnieuwk in #26)
+- [#26](https://github.com/nf-core/nft-utils/pull/26) Add `listToMD5` (@nvnieuwk).
 
 ### Fixed
 
-- Improve `getAllFilesInDir()` documentation (@jfy133)
-- Fix missing comma in documentation code (@Joon-Klaps)
-- Fix `listToMD5` (@maxulysse)
-- Improve `removeFromYamlMap` (@maxulysse)
+- [#24](https://github.com/nf-core/nft-utils/pull/24) Improve `getAllFilesInDir()` documentation (@jfy133).
+- [#28](https://github.com/nf-core/nft-utils/pull/28) Fix missing comma in documentation code (@Joon-Klaps).
+- [#34](https://github.com/nf-core/nft-utils/pull/34) Update usage docs and images (@itrujnara).
+- [#35](https://github.com/nf-core/nft-utils/pull/35) Improve `removeFromYamlMap` (@maxulysse).
+- [#36](https://github.com/nf-core/nft-utils/pull/36) Fix `listToMD5` (@maxulysse).
 
 ### New Contributors
 
@@ -112,42 +137,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - @Joon-Klaps
 - @itrujnara
 
-## [0.0.3]
+## 0.0.3
 
 ### Added
 
-- Add wrapper functions for `getAllFilesFromDir` with named parameters (@lukfor)
-- Add `include` in `getAllFilesFromDir` (@maxulysse)
-- Add `removeFromYamlMap` (@maxulysse)
+- [#15](https://github.com/nf-core/nft-utils/pull/15) Add Maven to Gitpod install (@nvnieuwk).
+- [#18](https://github.com/nf-core/nft-utils/pull/18) Add wrapper functions for `getAllFilesFromDir` with named parameters (@lukfor).
+- [#20](https://github.com/nf-core/nft-utils/pull/20) Add `removeFromYamlMap` (@maxulysse).
+- [#21](https://github.com/nf-core/nft-utils/pull/21) Add `include` in `getAllFilesFromDir` (@maxulysse).
 
 ### Fixed
 
-- Move documentation to its own folder (@maxulysse)
+- [#19](https://github.com/nf-core/nft-utils/pull/19) Move documentation to its own folder (@maxulysse).
 
 ### New Contributors
 
 - @lukfor
+- @nvnieuwk
 
-## [0.0.2]
+## 0.0.2
 
 ### Added
 
-- Add Maven to Gitpod install (@nvnieuwk)
-- Add `getRelativePath()` function (@maxulysse)
+- [#7](https://github.com/nf-core/nft-utils/pull/7) Add recursive file listing method (@JonathanManning).
+- [#16](https://github.com/nf-core/nft-utils/pull/16) Add `getRelativePath()` function (@maxulysse).
 
 ### New Contributors
 
-- @nvnieuwk
+- @JonathanManning
 
-## [0.0.1]
+## 0.0.1
 
-First release of nft-utils.
+First release of nft-utils 🍏🚀
 
 ### Added
 
-- Add `removeNextflowVersion` function (@maxulysse)
-- Add `getAllFilesFromDir` function (@maxulysse)
-- Add documentation (@maxulysse)
+- [#1](https://github.com/nf-core/nft-utils/pull/1) Initial repo setup (@adamrtalbot).
+- [#6](https://github.com/nf-core/nft-utils/pull/6) Add `removeNextflowVersion` function (@maxulysse).
+- [#7](https://github.com/nf-core/nft-utils/pull/7) Add `getAllFilesFromDir` function (@maxulysse).
+- [#9](https://github.com/nf-core/nft-utils/pull/9), [#11](https://github.com/nf-core/nft-utils/pull/11), [#12](https://github.com/nf-core/nft-utils/pull/12), [#13](https://github.com/nf-core/nft-utils/pull/13) Add documentation (@maxulysse).
 
 ### New Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,7 +175,8 @@ First release of nft-utils 🍏🚀
 
 - [#1](https://github.com/nf-core/nft-utils/pull/1) Initial repo setup (@adamrtalbot)
 - [#6](https://github.com/nf-core/nft-utils/pull/6) Add `removeNextflowVersion` function (@maxulysse)
-- [#9](https://github.com/nf-core/nft-utils/pull/9), [#11](https://github.com/nf-core/nft-utils/pull/11), [#12](https://github.com/nf-core/nft-utils/pull/12) Add documentation (@maxulysse, @adamrtalbot)
+- [#9](https://github.com/nf-core/nft-utils/pull/9), [#11](https://github.com/nf-core/nft-utils/pull/11) Add documentation (@maxulysse, @adamrtalbot)
+- [#12](https://github.com/nf-core/nft-utils/pull/12) Add ignore file (@maxulysse)
 
 ### New Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [#15](https://github.com/nf-core/nft-utils/pull/15) Add Maven to Gitpod install (@nvnieuwk).
 - [#18](https://github.com/nf-core/nft-utils/pull/18) Add wrapper functions for `getAllFilesFromDir` with named parameters (@lukfor).
 - [#20](https://github.com/nf-core/nft-utils/pull/20) Add `removeFromYamlMap` (@maxulysse).
 - [#21](https://github.com/nf-core/nft-utils/pull/21) Add `include` in `getAllFilesFromDir` (@maxulysse).
@@ -153,18 +152,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Contributors
 
 - @lukfor
-- @nvnieuwk
 
 ## 0.0.2
 
 ### Added
 
 - [#7](https://github.com/nf-core/nft-utils/pull/7) Add recursive file listing method (@JonathanManning).
+- [#15](https://github.com/nf-core/nft-utils/pull/15) Add Maven to Gitpod install (@nvnieuwk).
 - [#16](https://github.com/nf-core/nft-utils/pull/16) Add `getRelativePath()` function (@maxulysse).
 
 ### New Contributors
 
 - @JonathanManning
+- @nvnieuwk
 
 ## 0.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [#7](https://github.com/nf-core/nft-utils/pull/7) Add recursive file listing method (@JonathanManning).
 - [#15](https://github.com/nf-core/nft-utils/pull/15) Add Maven to Gitpod install (@nvnieuwk).
 - [#16](https://github.com/nf-core/nft-utils/pull/16) Add `getRelativePath()` function (@maxulysse).
 
@@ -175,7 +174,7 @@ First release of nft-utils 🍏🚀
 - [#1](https://github.com/nf-core/nft-utils/pull/1) Initial repo setup (@adamrtalbot).
 - [#6](https://github.com/nf-core/nft-utils/pull/6) Add `removeNextflowVersion` function (@maxulysse).
 - [#7](https://github.com/nf-core/nft-utils/pull/7) Add `getAllFilesFromDir` function (@maxulysse).
-- [#9](https://github.com/nf-core/nft-utils/pull/9), [#11](https://github.com/nf-core/nft-utils/pull/11), [#12](https://github.com/nf-core/nft-utils/pull/12), [#13](https://github.com/nf-core/nft-utils/pull/13) Add documentation (@maxulysse).
+- [#9](https://github.com/nf-core/nft-utils/pull/9), [#11](https://github.com/nf-core/nft-utils/pull/11), [#12](https://github.com/nf-core/nft-utils/pull/12), [#13](https://github.com/nf-core/nft-utils/pull/13) Add documentation (@maxulysse, @adamrtalbot).
 
 ### New Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,52 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [#90](https://github.com/nf-core/nft-utils/pull/90) Implement `additionalPatterns` parameter in `filterNextflowOutput` (@maxulysse).
+- [#90](https://github.com/nf-core/nft-utils/pull/90) Implement `additionalPatterns` parameter in `filterNextflowOutput` (@maxulysse)
 
 ### Changed
 
-- [#90](https://github.com/nf-core/nft-utils/pull/90) Refactor `Methods.java` into separate utility classes (`HashUtils`, `YamlUtils`, `ArchiveDownloader`, `FileTraversalUtils`, `NextflowOutputFilter`) (@maxulysse).
+- [#90](https://github.com/nf-core/nft-utils/pull/90) Refactor `Methods.java` into separate utility classes (`HashUtils`, `YamlUtils`, `ArchiveDownloader`, `FileTraversalUtils`, `NextflowOutputFilter`) (@maxulysse)
+- [#90](https://github.com/nf-core/nft-utils/pull/90) More standardized CHANGELOG (@maxulysse)
 
 ### Fixed
 
-- [#90](https://github.com/nf-core/nft-utils/pull/90) `ArchiveDownloader` and `NfCoreUtils.installModule` now throw `IOException` on failure (@maxulysse).
-- [#90](https://github.com/nf-core/nft-utils/pull/90) Fix raw types in public API signatures (@maxulysse).
+- [#90](https://github.com/nf-core/nft-utils/pull/90) `ArchiveDownloader` and `NfCoreUtils.installModule` now throw `IOException` on failure (@maxulysse)
+- [#90](https://github.com/nf-core/nft-utils/pull/90) Fix raw types in public API signatures (@maxulysse)
 
 ## 1.2.0
 
 ### Added
 
-- [#86](https://github.com/nf-core/nft-utils/pull/86) Add `csvMD5Keys` for `sanitizeOutput` to hash normalized CSV content (@LouisLeNezet).
+- [#86](https://github.com/nf-core/nft-utils/pull/86) Add `csvMD5Keys` for `sanitizeOutput` to hash normalized CSV content (@LouisLeNezet)
 
 ### Fixed
 
-- [#85](https://github.com/nf-core/nft-utils/pull/85) Fix empty value usage in `sanitizeOutput()`. See [#84](https://github.com/nf-core/nft-utils/issues/84) (@LouisLeNezet).
+- [#85](https://github.com/nf-core/nft-utils/pull/85) Fix empty value usage in `sanitizeOutput()`. See [#84](https://github.com/nf-core/nft-utils/issues/84) (@LouisLeNezet)
 
 ### Changed
 
-- [#88](https://github.com/nf-core/nft-utils/pull/88) Clean up documentation prose, add feature list to README, standardize CHANGELOG (@maxulysse).
+- [#88](https://github.com/nf-core/nft-utils/pull/88) Clean up documentation prose, add feature list to README, standardize CHANGELOG (@maxulysse)
 
 ## 1.1.1
 
 ### Fixed
 
-- [#83](https://github.com/nf-core/nft-utils/pull/83) Use `unstablePatterns` and `ignorePatterns` instead of `unstablePattern` and `ignorePattern` (@LouisLeNezet).
+- [#83](https://github.com/nf-core/nft-utils/pull/83) Use `unstablePatterns` and `ignorePatterns` instead of `unstablePattern` and `ignorePattern` (@LouisLeNezet)
 
 ## 1.1.0
 
 ### Added
 
-- [#75](https://github.com/nf-core/nft-utils/pull/75) Add `ignoreKeys` for `sanitizeOutput` and key presence check (@LouisLeNezet).
-- [#76](https://github.com/nf-core/nft-utils/pull/76) Add `readsMD5Keys` and `variantsMD5Keys` for `sanitizeOutput` to hash reads and variants separately (@LouisLeNezet).
-- [#77](https://github.com/nf-core/nft-utils/pull/77) Add `unstablePattern` and `ignorePattern` to `sanitizeOutput` for glob-based filtering (@LouisLeNezet).
+- [#75](https://github.com/nf-core/nft-utils/pull/75) Add `ignoreKeys` for `sanitizeOutput` and key presence check (@LouisLeNezet)
+- [#76](https://github.com/nf-core/nft-utils/pull/76) Add `readsMD5Keys` and `variantsMD5Keys` for `sanitizeOutput` to hash reads and variants separately (@LouisLeNezet)
+- [#77](https://github.com/nf-core/nft-utils/pull/77) Add `unstablePattern` and `ignorePattern` to `sanitizeOutput` for glob-based filtering (@LouisLeNezet)
 
 ### Fixed
 
-- [#74](https://github.com/nf-core/nft-utils/pull/74) Fix `unstableKeys` usage for `sanitizeOutput` when a folder is passed (@LouisLeNezet).
-- [#78](https://github.com/nf-core/nft-utils/pull/78) Fix linting with `mvn checkstyle:check` and restructure folders (@LouisLeNezet).
-- [#79](https://github.com/nf-core/nft-utils/pull/79) Use glob patterns instead of regex for `ignorePattern` and `unstablePattern` (@LouisLeNezet).
-- [#80](https://github.com/nf-core/nft-utils/pull/80) Update GitHub Actions to use environment and cache; add linting and bug checks to Maven lifecycle (@LouisLeNezet).
-- [#81](https://github.com/nf-core/nft-utils/pull/81) Fix `nfcoreInitialise()` for nf-core tools 4.1.0 compatibility (requires `conf/` directory) (@JimDownie).
+- [#74](https://github.com/nf-core/nft-utils/pull/74) Fix `unstableKeys` usage for `sanitizeOutput` when a folder is passed (@LouisLeNezet)
+- [#78](https://github.com/nf-core/nft-utils/pull/78) Fix linting with `mvn checkstyle:check` and restructure folders (@LouisLeNezet)
+- [#79](https://github.com/nf-core/nft-utils/pull/79) Use glob patterns instead of regex for `ignorePattern` and `unstablePattern` (@LouisLeNezet)
+- [#80](https://github.com/nf-core/nft-utils/pull/80) Update GitHub Actions to use environment and cache; add linting and bug checks to Maven lifecycle (@LouisLeNezet)
+- [#81](https://github.com/nf-core/nft-utils/pull/81) Fix `nfcoreInitialise()` for nf-core tools 4.1.0 compatibility (requires `conf/` directory) (@JimDownie)
 
 ### New Contributors
 
@@ -62,21 +63,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [#69](https://github.com/nf-core/nft-utils/pull/69) Add `getAllFilesFromPath()` to retrieve files from local or S3 paths with `include`/`ignore` glob patterns, `includeDir`, and `noSignRequest` for S3 (@maxulysse).
+- [#69](https://github.com/nf-core/nft-utils/pull/69) Add `getAllFilesFromPath()` to retrieve files from local or S3 paths with `include`/`ignore` glob patterns, `includeDir`, and `noSignRequest` for S3 (@maxulysse)
 
 ## 0.0.9
 
 ### Added
 
-- [#61](https://github.com/nf-core/nft-utils/pull/61) `nfcoreInstall()` now tracks installed modules via state files, skipping already installed modules (@JimDownie).
-- [#62](https://github.com/nf-core/nft-utils/pull/62) Add `getAllFilesFromChannel()` to extract absolute file paths from Nextflow channel output (@maxulysse).
-- [#63](https://github.com/nf-core/nft-utils/pull/63) Add `filterNextflowOutput()` to clean Nextflow stdout/stderr with `include`/`ignore` filters and `keepAnsi` option (@maxulysse).
+- [#61](https://github.com/nf-core/nft-utils/pull/61) `nfcoreInstall()` now tracks installed modules via state files, skipping already installed modules (@JimDownie)
+- [#62](https://github.com/nf-core/nft-utils/pull/62) Add `getAllFilesFromChannel()` to extract absolute file paths from Nextflow channel output (@maxulysse)
+- [#63](https://github.com/nf-core/nft-utils/pull/63) Add `filterNextflowOutput()` to clean Nextflow stdout/stderr with `include`/`ignore` filters and `keepAnsi` option (@maxulysse)
 
 ## 0.0.8
 
 ### Added
 
-- [#55](https://github.com/nf-core/nft-utils/pull/55) Add `curlAndExtract()` to download and extract `tar` and `zip` files during nf-test setup (@muffato).
+- [#55](https://github.com/nf-core/nft-utils/pull/55) Add `curlAndExtract()` to download and extract `tar` and `zip` files during nf-test setup (@muffato)
 
 ### New Contributors
 
@@ -86,31 +87,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [#48](https://github.com/nf-core/nft-utils/pull/48) Add `OutputSanitizer` class with `sanitizeOutput()` to process and clean output channels, supporting `unstableKeys` for unstable file paths (@nvnieuwk).
+- [#48](https://github.com/nf-core/nft-utils/pull/48) Add `OutputSanitizer` class with `sanitizeOutput()` to process and clean output channels, supporting `unstableKeys` for unstable file paths (@nvnieuwk)
 
 ### Fixed
 
-- [#50](https://github.com/nf-core/nft-utils/pull/50) `nfcoreLibraryLinker`: exit gracefully when directories don't exist (@prototaxites).
+- [#50](https://github.com/nf-core/nft-utils/pull/50) `nfcoreLibraryLinker`: exit gracefully when directories don't exist (@prototaxites)
 
 ## 0.0.6
 
 ### Added
 
-- [#45](https://github.com/nf-core/nft-utils/pull/45) Add stdout and stderr helper functions for better snapshots (@maxulysse).
+- [#45](https://github.com/nf-core/nft-utils/pull/45) Add stdout and stderr helper functions for better snapshots (@maxulysse)
 
 ### Fixed
 
-- [#44](https://github.com/nf-core/nft-utils/pull/44) Improve documentation (@maxulysse).
+- [#44](https://github.com/nf-core/nft-utils/pull/44) Improve documentation (@maxulysse)
 
 ## 0.0.5
 
 ### Added
 
-- [#42](https://github.com/nf-core/nft-utils/pull/42) Add functions for managing dependencies on nf-core modules (@prototaxites).
+- [#42](https://github.com/nf-core/nft-utils/pull/42) Add functions for managing dependencies on nf-core modules (@prototaxites)
 
 ### Fixed
 
-- [#41](https://github.com/nf-core/nft-utils/pull/41) Fix rendering of cloning code blocks (@TCLamnidis).
+- [#41](https://github.com/nf-core/nft-utils/pull/41) Fix rendering of cloning code blocks (@TCLamnidis)
 
 ### New Contributors
 
@@ -121,15 +122,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [#26](https://github.com/nf-core/nft-utils/pull/26) Add `listToMD5` (@nvnieuwk).
+- [#26](https://github.com/nf-core/nft-utils/pull/26) Add `listToMD5` (@nvnieuwk)
 
 ### Fixed
 
-- [#24](https://github.com/nf-core/nft-utils/pull/24) Improve `getAllFilesInDir()` documentation (@jfy133).
-- [#28](https://github.com/nf-core/nft-utils/pull/28) Fix missing comma in documentation code (@Joon-Klaps).
-- [#34](https://github.com/nf-core/nft-utils/pull/34) Update usage docs and images (@itrujnara).
-- [#35](https://github.com/nf-core/nft-utils/pull/35) Improve `removeFromYamlMap` (@maxulysse).
-- [#36](https://github.com/nf-core/nft-utils/pull/36) Fix `listToMD5` (@maxulysse).
+- [#24](https://github.com/nf-core/nft-utils/pull/24) Improve `getAllFilesInDir()` documentation (@jfy133)
+- [#28](https://github.com/nf-core/nft-utils/pull/28) Fix missing comma in documentation code (@Joon-Klaps)
+- [#34](https://github.com/nf-core/nft-utils/pull/34) Update usage docs and images (@itrujnara)
+- [#35](https://github.com/nf-core/nft-utils/pull/35) Improve `removeFromYamlMap` (@maxulysse)
+- [#36](https://github.com/nf-core/nft-utils/pull/36) Fix `listToMD5` (@maxulysse)
 
 ### New Contributors
 
@@ -141,13 +142,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [#18](https://github.com/nf-core/nft-utils/pull/18) Add wrapper functions for `getAllFilesFromDir` with named parameters (@lukfor).
-- [#20](https://github.com/nf-core/nft-utils/pull/20) Add `removeFromYamlMap` (@maxulysse).
-- [#21](https://github.com/nf-core/nft-utils/pull/21) Add `include` in `getAllFilesFromDir` (@maxulysse).
+- [#18](https://github.com/nf-core/nft-utils/pull/18) Add wrapper functions for `getAllFilesFromDir` with named parameters (@lukfor)
+- [#20](https://github.com/nf-core/nft-utils/pull/20) Add `removeFromYamlMap` (@maxulysse)
+- [#21](https://github.com/nf-core/nft-utils/pull/21) Add `include` in `getAllFilesFromDir` (@maxulysse)
 
 ### Fixed
 
-- [#19](https://github.com/nf-core/nft-utils/pull/19) Move documentation to its own folder (@maxulysse).
+- [#19](https://github.com/nf-core/nft-utils/pull/19) Move documentation to its own folder (@maxulysse)
 
 ### New Contributors
 
@@ -157,9 +158,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [#7](https://github.com/nf-core/nft-utils/pull/7) Add recursive file listing method (@JonathanManning, @maxulysse).
-- [#15](https://github.com/nf-core/nft-utils/pull/15) Add Maven to Gitpod install (@nvnieuwk).
-- [#16](https://github.com/nf-core/nft-utils/pull/16) Add `getRelativePath()` function (@maxulysse).
+- [#7](https://github.com/nf-core/nft-utils/pull/7) Add recursive file listing method (@JonathanManning, @maxulysse)
+- [#15](https://github.com/nf-core/nft-utils/pull/15) Add Maven to Gitpod install (@nvnieuwk)
+- [#16](https://github.com/nf-core/nft-utils/pull/16) Add `getRelativePath()` function (@maxulysse)
 
 ### New Contributors
 
@@ -172,9 +173,9 @@ First release of nft-utils 🍏🚀
 
 ### Added
 
-- [#1](https://github.com/nf-core/nft-utils/pull/1) Initial repo setup (@adamrtalbot).
-- [#6](https://github.com/nf-core/nft-utils/pull/6) Add `removeNextflowVersion` function (@maxulysse).
-- [#9](https://github.com/nf-core/nft-utils/pull/9), [#11](https://github.com/nf-core/nft-utils/pull/11), [#12](https://github.com/nf-core/nft-utils/pull/12) Add documentation (@maxulysse, @adamrtalbot).
+- [#1](https://github.com/nf-core/nft-utils/pull/1) Initial repo setup (@adamrtalbot)
+- [#6](https://github.com/nf-core/nft-utils/pull/6) Add `removeNextflowVersion` function (@maxulysse)
+- [#9](https://github.com/nf-core/nft-utils/pull/9), [#11](https://github.com/nf-core/nft-utils/pull/11), [#12](https://github.com/nf-core/nft-utils/pull/12) Add documentation (@maxulysse, @adamrtalbot)
 
 ### New Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [ad18623](https://github.com/nf-core/nft-utils/commit/ad18623) Add recursive file listing method (@JonathanManning).
+- [#7](https://github.com/nf-core/nft-utils/pull/7) Add recursive file listing method (@JonathanManning, @maxulysse).
 - [#15](https://github.com/nf-core/nft-utils/pull/15) Add Maven to Gitpod install (@nvnieuwk).
 - [#16](https://github.com/nf-core/nft-utils/pull/16) Add `getRelativePath()` function (@maxulysse).
 
@@ -174,7 +174,6 @@ First release of nft-utils 🍏🚀
 
 - [#1](https://github.com/nf-core/nft-utils/pull/1) Initial repo setup (@adamrtalbot).
 - [#6](https://github.com/nf-core/nft-utils/pull/6) Add `removeNextflowVersion` function (@maxulysse).
-- [#7](https://github.com/nf-core/nft-utils/pull/7) Add `getAllFilesFromDir` function (@maxulysse).
 - [#9](https://github.com/nf-core/nft-utils/pull/9), [#11](https://github.com/nf-core/nft-utils/pull/11), [#12](https://github.com/nf-core/nft-utils/pull/12) Add documentation (@maxulysse, @adamrtalbot).
 
 ### New Contributors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [ad18623](https://github.com/nf-core/nft-utils/commit/ad18623) Add recursive file listing method (@JonathanManning).
 - [#15](https://github.com/nf-core/nft-utils/pull/15) Add Maven to Gitpod install (@nvnieuwk).
 - [#16](https://github.com/nf-core/nft-utils/pull/16) Add `getRelativePath()` function (@maxulysse).
 

--- a/src/main/java/nfcore/nftest/utils/ArchiveDownloader.java
+++ b/src/main/java/nfcore/nftest/utils/ArchiveDownloader.java
@@ -1,0 +1,474 @@
+package nfcore.nftest.utils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+/**
+ * Utility methods for downloading and extracting archive files from URLs
+ * and cloud storage.
+ */
+public final class ArchiveDownloader {
+
+  /**
+   * Prevents instantiation of this utility class.
+   */
+  private ArchiveDownloader() {
+  }
+
+  /**
+   * Number of fields expected in an AWS S3 CLI listing line.
+   */
+  private static final int AWS_S3_LIST_FIELDS = 4;
+
+  /**
+   * Index of the object key in an AWS S3 CLI listing line.
+   */
+  private static final int AWS_S3_KEY_INDEX = 3;
+
+  /**
+   * Length of the URI scheme separator.
+   */
+  private static final int SCHEME_SEPARATOR_LENGTH = 3;
+
+  /**
+   * Download a tar archive and extract it in the given destination directory.
+   * The file is streamed directly with {@code curl} into {@code tar} via a
+   * pipe. The compression type must be provided if applicable.
+   * Uses safe single-quoting for the URL and destination path.
+   *
+   * @param urlString   the URL to fetch
+   * @param destPath    directory to extract the tarball into
+   * @param compression compression type: tar, gzip, gz, bzip2, bz2, xz, lz4,
+   *                    lzma, lzop, zstd
+   * @throws IOException on failure
+   */
+  static void curlAndUntar(
+      final String urlString,
+      final String destPath,
+      final String compression)
+      throws IOException {
+    Path destDir = Paths.get(destPath);
+    Files.createDirectories(destDir);
+
+    String escUrl = Utils.shellEscape(urlString);
+    String escDest = Utils.shellEscape(destPath);
+    String cmd = "curl -L --retry 5 " + escUrl
+      + " | tar xaf - -C " + escDest;
+    String tarExt = compression;
+
+    if (tarExt != null && !tarExt.equals("tar")) {
+      if (tarExt.startsWith("tar.")) {
+        tarExt = tarExt.substring("tar.".length());
+      } else if (tarExt.startsWith("t")) {
+        tarExt = tarExt.substring("t".length());
+      }
+
+      if (tarExt.equals("gzip") || tarExt.equals("gz")) {
+        tarExt = "gzip";
+      } else if (tarExt.equals("bzip2") || tarExt.equals("bz2")) {
+        tarExt = "bzip2";
+      } else if (tarExt.equals("xz")) {
+        tarExt = "xz";
+      } else if (tarExt.equals("lz4")) {
+        tarExt = "lz4";
+      } else if (tarExt.equals("lzma")) {
+        tarExt = "lzma";
+      } else if (tarExt.equals("lzop")) {
+        tarExt = "lzop";
+      } else if (tarExt.equals("zstd") || tarExt.equals("zst")) {
+        tarExt = "zstd";
+      } else {
+        throw new IllegalArgumentException(
+          "Unsupported compression type: " + tarExt
+        );
+      }
+      cmd += " --" + tarExt;
+    }
+
+    ProcessBuilder pb = new ProcessBuilder("sh", "-c", cmd);
+    try {
+      Utils.ProcessResult result = Utils.runProcess(pb);
+      if (result.getExitCode() != 0) {
+        System.err
+            .println(
+              "Error downloading and extracting file "
+              + urlString + ": exit code "
+              + result.getExitCode() + "\n"
+            );
+        System.out.println("Bash command: \n" + cmd);
+        System.err.println("command output: \n");
+        System.err.println(result.getStderr());
+      } else {
+        System.out.println(
+          "Successfully downloaded and extracted file: "
+          + urlString
+        );
+      }
+    } catch (IOException | InterruptedException e) {
+      System.err.println(
+        "Error downloading and extracting file "
+        + urlString + ": " + e.getMessage()
+      );
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * Download a zip file and extract it in the given destination directory.
+   * The file is first downloaded with {@code curl} to a temporary file, then
+   * {@code unzip} is called and the temporary file is deleted.
+   *
+   * @param urlString the URL to fetch
+   * @param destPath  directory to extract the zip into
+   * @throws IOException on failure
+   */
+  static void curlAndUnzip(
+      final String urlString,
+      final String destPath)
+      throws IOException {
+    Path destDir = Paths.get(destPath);
+    Files.createDirectories(destDir);
+
+    Path tempFile = Files.createTempFile(destDir, "download", ".zip");
+
+    ProcessBuilder pb = new ProcessBuilder(
+        "curl",
+        "-L",
+        "--retry",
+        "5",
+        "-o",
+        tempFile.toString(),
+        urlString);
+
+    try {
+      Utils.ProcessResult result = Utils.runProcess(pb);
+      if (result.getExitCode() != 0) {
+        System.err.println(
+          "Error downloading file " + urlString
+          + ": exit code " + result.getExitCode() + "\n"
+        );
+        System.out.println("Command: " + String.join(" ", pb.command()));
+        System.err.println("command output: \n");
+        System.err.println(result.getStderr());
+        return;
+      }
+      pb = new ProcessBuilder(
+          "unzip",
+          "-o",
+          tempFile.toString(),
+          "-d",
+          destPath);
+      result = Utils.runProcess(pb);
+      if (result.getExitCode() != 0) {
+        System.err.println(
+          "Error extracting zip " + tempFile
+          + ": exit code " + result.getExitCode() + "\n"
+        );
+        System.out.println("Command: " + String.join(" ", pb.command()));
+        System.err.println("command output: \n");
+        System.err.println(result.getStderr());
+      } else {
+        System.out.println(
+          "Successfully downloaded and extracted file: "
+          + urlString
+        );
+      }
+    } catch (IOException | InterruptedException e) {
+      System.err.println(
+        "Error downloading and extracting file "
+        + urlString + ": " + e.getMessage()
+      );
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+    } finally {
+      try {
+        Files.deleteIfExists(tempFile);
+      } catch (IOException e) {
+        System.err.println(
+          "Warning: failed to delete temporary file "
+          + tempFile + ": " + e.getMessage()
+        );
+      }
+    }
+  }
+
+  /**
+   * Download an archive and extract it in the given destination directory.
+   * Dispatches to {@code curlAndUnzip} for ZIP files and to
+   * {@code curlAndUntar} for tar archives based on the URL's file extension.
+   *
+   * @param urlString the URL to fetch
+   * @param destPath  directory to extract the archive into
+   * @throws IOException on failure or if archive type is unsupported
+   */
+  public static void curlAndExtract(
+      final String urlString,
+      final String destPath)
+      throws IOException {
+    String lower = Utils.getURLFileName(urlString);
+
+    if (lower.endsWith(".zip")) {
+      curlAndUnzip(urlString, destPath);
+      return;
+    }
+
+    for (String suffix : new String[] {
+        "gz", "bz2", "xz", "lz4", "lzma", "lzop", "zst", "zstd"
+      }) {
+      if (lower.endsWith(".tar." + suffix) || lower.endsWith(".t" + suffix)) {
+        curlAndUntar(urlString, destPath, suffix);
+        return;
+      }
+    }
+
+    if (lower.endsWith(".tar")) {
+      curlAndUntar(urlString, destPath, null);
+      return;
+    }
+
+    throw new IllegalArgumentException(
+      "Unsupported archive type in URL: " + urlString
+    );
+  }
+
+  /**
+   * Download an archive and extract it in the given destination directory.
+   * Dispatches to {@code curlAndUnzip} for ZIP files and to
+   * {@code curlAndUntar} for tar archives based on the {@code compression}
+   * parameter.
+   *
+   * @param urlString   the URL to fetch
+   * @param destPath    directory to extract the archive into
+   * @param compression compression type: zip, tar, or any of the following
+   *                    prefixed with "tar." or "t":
+   *                    gzip, gz, bzip2, bz2, xz, lz4, lzma, lzop, zstd
+   * @throws IOException on failure or if archive type is unsupported
+   */
+  public static void curlAndExtract(
+      final String urlString,
+      final String destPath,
+      final String compression)
+      throws IOException {
+    if (compression == null || compression.isEmpty()) {
+      throw new IllegalArgumentException(
+        "The 'compression' parameter is required."
+      );
+    }
+    String lower = compression.toLowerCase(Locale.ROOT);
+    if (lower.equals("zip")) {
+      curlAndUnzip(urlString, destPath);
+    } else if (lower.equals("tar")) {
+      curlAndUntar(urlString, destPath, null);
+    } else if (lower.startsWith("tar.")) {
+      curlAndUntar(urlString, destPath, compression);
+    } else if (lower.startsWith("t")) {
+      curlAndUntar(urlString, destPath, compression);
+    } else {
+      throw new IllegalArgumentException(
+        "Unsupported compression type: "
+        + compression
+      );
+    }
+  }
+
+  /**
+   * Lists files under an S3 prefix using the AWS CLI
+   * ({@code aws s3 ls --recursive}).
+   *
+   * @param s3Path The S3 path or prefix to list.
+   * @param includeMatchers Path matchers for files to include.
+   * @param excludeMatchers Path matchers for files to exclude.
+   * @param includeDir Whether directory markers should be included.
+   * @param noSignRequest Whether to use {@code --no-sign-request}.
+   * @return A sorted list of S3 object keys matching the filters.
+   * @throws IOException If an I/O error occurs.
+   * @throws InterruptedException If the thread is interrupted.
+   */
+  static List<String> getAllFilesFromS3ViaCli(
+      final String s3Path,
+      final List<PathMatcher> includeMatchers,
+      final List<PathMatcher> excludeMatchers,
+      final boolean includeDir,
+      final boolean noSignRequest)
+      throws IOException, InterruptedException {
+
+    String normalizedPath = s3Path;
+    if (!s3Path.endsWith("/")) {
+      normalizedPath += "/";
+    }
+    String bucketAndPrefix = normalizedPath.substring("s3://".length());
+    int firstSlash = bucketAndPrefix.indexOf('/');
+    String prefix;
+    if (firstSlash >= 0) {
+      prefix = bucketAndPrefix.substring(firstSlash + 1);
+    } else {
+      prefix = "";
+    }
+
+    List<String> cmd = new ArrayList<>(
+      Arrays.asList("aws", "s3", "ls", "--recursive")
+    );
+    if (noSignRequest) {
+      cmd.add("--no-sign-request");
+    }
+    cmd.add(normalizedPath);
+
+    ProcessBuilder pb = new ProcessBuilder(cmd);
+    pb.redirectErrorStream(false);
+    Process process = pb.start();
+
+    List<String> files = new ArrayList<>();
+    try (BufferedReader reader = new BufferedReader(
+        new InputStreamReader(
+          process.getInputStream(),
+          StandardCharsets.UTF_8
+        )
+    )) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        String[] parts = line.trim().split("\\s+", AWS_S3_LIST_FIELDS);
+        if (parts.length < AWS_S3_LIST_FIELDS) {
+          continue;
+        }
+
+        String fullKey = parts[AWS_S3_KEY_INDEX];
+        String relativePath;
+        if (!prefix.isEmpty() && fullKey.startsWith(prefix)) {
+          relativePath = fullKey.substring(prefix.length());
+        } else {
+          relativePath = fullKey;
+        }
+
+        if (relativePath.isEmpty()) {
+          continue;
+        }
+
+        boolean isDir = relativePath.endsWith("/");
+        if (isDir && !includeDir) {
+          continue;
+        }
+
+        final String pathString;
+        if (isDir) {
+          pathString = relativePath.substring(0, relativePath.length() - 1);
+        } else {
+          pathString = relativePath;
+        }
+        Path relPath = Paths.get(pathString);
+        boolean included = includeMatchers.isEmpty()
+            || includeMatchers.stream().anyMatch(m -> m.matches(relPath));
+        boolean excluded = excludeMatchers
+          .stream()
+          .anyMatch(m -> m.matches(relPath));
+        if (included && !excluded) {
+          files.add(relativePath);
+        }
+      }
+    }
+
+    int exitCode = process.waitFor();
+    if (exitCode != 0) {
+      throw new IOException(
+          "AWS CLI returned exit code " + exitCode
+          + " when listing: " + normalizedPath);
+    }
+
+    return files.stream().sorted().collect(Collectors.toList());
+  }
+
+  /**
+   * Downloads a single file from a cloud URI to a temporary local directory
+   * and returns the local {@link Path}.
+   *
+   * @param cloudUri The cloud URI of the file to download
+   * @return A {@link Path} pointing to the downloaded local file
+   * @throws IOException if {@code nextflow fs cp} fails
+   * @throws InterruptedException if the process is interrupted
+   */
+  public static Path downloadFromS3(
+      final String cloudUri)
+      throws IOException, InterruptedException {
+    return downloadFromS3(
+      new LinkedHashMap<String, Object>(),
+      cloudUri);
+  }
+
+  /**
+   * Downloads a single file from a cloud URI to a temporary local directory
+   * and returns the local {@link Path}.
+   *
+   * @param options Reserved for future use (currently unused)
+   * @param cloudUri The cloud URI of the file to download
+   * @return A {@link Path} pointing to the downloaded local file
+   * @throws IOException if {@code nextflow fs cp} fails
+   * @throws InterruptedException if the process is interrupted
+   */
+  public static Path downloadFromS3(
+      final LinkedHashMap<String, Object> options,
+      final String cloudUri)
+      throws IOException, InterruptedException {
+    if (cloudUri == null || cloudUri.isEmpty()) {
+      throw new IllegalArgumentException(
+        "The 'cloudUri' parameter is required."
+      );
+    }
+
+    int schemeEnd = cloudUri.indexOf("://");
+    String withoutScheme;
+    if (schemeEnd >= 0) {
+      withoutScheme = cloudUri.substring(
+        schemeEnd + SCHEME_SEPARATOR_LENGTH
+      );
+    } else {
+      withoutScheme = cloudUri;
+    }
+
+    int firstSlash = withoutScheme.indexOf('/');
+    String relativeKey;
+    if (firstSlash >= 0) {
+      relativeKey = withoutScheme.substring(firstSlash + 1);
+    } else {
+      relativeKey = withoutScheme;
+    }
+
+    Path destFile = Paths.get(
+      System.getProperty("java.io.tmpdir"),
+      "nft-utils-cloud", relativeKey
+    );
+    Path destParent = destFile.getParent();
+    if (destParent != null) {
+      Files.createDirectories(destParent);
+    }
+
+    List<String> cmd = Arrays.asList(
+      "nextflow", "fs", "cp",
+      cloudUri, destFile.toString()
+    );
+    ProcessBuilder pb = new ProcessBuilder(cmd);
+    pb.redirectErrorStream(false);
+    Process process = pb.start();
+    int exitCode = process.waitFor();
+    if (exitCode != 0) {
+      throw new IOException(
+          "nextflow fs cp returned exit code " + exitCode
+          + " when downloading: " + cloudUri);
+    }
+
+    return destFile;
+  }
+}

--- a/src/main/java/nfcore/nftest/utils/ArchiveDownloader.java
+++ b/src/main/java/nfcore/nftest/utils/ArchiveDownloader.java
@@ -98,33 +98,26 @@ public final class ArchiveDownloader {
     }
 
     ProcessBuilder pb = new ProcessBuilder("sh", "-c", cmd);
+    Utils.ProcessResult result;
     try {
-      Utils.ProcessResult result = Utils.runProcess(pb);
-      if (result.getExitCode() != 0) {
-        System.err
-            .println(
-              "Error downloading and extracting file "
-              + urlString + ": exit code "
-              + result.getExitCode() + "\n"
-            );
-        System.out.println("Bash command: \n" + cmd);
-        System.err.println("command output: \n");
-        System.err.println(result.getStderr());
-      } else {
-        System.out.println(
-          "Successfully downloaded and extracted file: "
-          + urlString
-        );
-      }
-    } catch (IOException | InterruptedException e) {
-      System.err.println(
-        "Error downloading and extracting file "
-        + urlString + ": " + e.getMessage()
+      result = Utils.runProcess(pb);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException(
+        "Interrupted while downloading " + urlString, e
       );
-      if (e instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-      }
     }
+    if (result.getExitCode() != 0) {
+      throw new IOException(
+        "Failed to download and extract " + urlString
+        + ": exit code " + result.getExitCode() + "\n"
+        + result.getStderr()
+      );
+    }
+    System.out.println(
+      "Successfully downloaded and extracted file: "
+      + urlString
+    );
   }
 
   /**
@@ -157,14 +150,11 @@ public final class ArchiveDownloader {
     try {
       Utils.ProcessResult result = Utils.runProcess(pb);
       if (result.getExitCode() != 0) {
-        System.err.println(
-          "Error downloading file " + urlString
+        throw new IOException(
+          "Failed to download " + urlString
           + ": exit code " + result.getExitCode() + "\n"
+          + result.getStderr()
         );
-        System.out.println("Command: " + String.join(" ", pb.command()));
-        System.err.println("command output: \n");
-        System.err.println(result.getStderr());
-        return;
       }
       pb = new ProcessBuilder(
           "unzip",
@@ -174,27 +164,21 @@ public final class ArchiveDownloader {
           destPath);
       result = Utils.runProcess(pb);
       if (result.getExitCode() != 0) {
-        System.err.println(
-          "Error extracting zip " + tempFile
+        throw new IOException(
+          "Failed to extract zip " + tempFile
           + ": exit code " + result.getExitCode() + "\n"
-        );
-        System.out.println("Command: " + String.join(" ", pb.command()));
-        System.err.println("command output: \n");
-        System.err.println(result.getStderr());
-      } else {
-        System.out.println(
-          "Successfully downloaded and extracted file: "
-          + urlString
+          + result.getStderr()
         );
       }
-    } catch (IOException | InterruptedException e) {
-      System.err.println(
-        "Error downloading and extracting file "
-        + urlString + ": " + e.getMessage()
+      System.out.println(
+        "Successfully downloaded and extracted file: "
+        + urlString
       );
-      if (e instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException(
+        "Interrupted while downloading " + urlString, e
+      );
     } finally {
       try {
         Files.deleteIfExists(tempFile);

--- a/src/main/java/nfcore/nftest/utils/CsvUtils.java
+++ b/src/main/java/nfcore/nftest/utils/CsvUtils.java
@@ -23,6 +23,9 @@ import org.apache.commons.csv.CSVRecord;
  */
 public final class CsvUtils {
 
+  /** Default number of decimal places for CSV double values. */
+  public static final int DEFAULT_DOUBLE_DIGITS = 6;
+
   /**
    * Prevents instantiation of this utility class.
    */

--- a/src/main/java/nfcore/nftest/utils/CsvUtils.java
+++ b/src/main/java/nfcore/nftest/utils/CsvUtils.java
@@ -5,11 +5,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Comparator;
-import java.util.Locale;
 import java.util.stream.Collectors;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -422,23 +420,7 @@ public final class CsvUtils {
    */
   private static String md5(final String value)
     throws NoSuchAlgorithmException {
-
-    final MessageDigest digest =
-      MessageDigest.getInstance("MD5");
-
-    final byte[] hash = digest.digest(
-      value.getBytes(StandardCharsets.UTF_8)
-    );
-
-    final StringBuilder result = new StringBuilder();
-
-    for (final byte b : hash) {
-      result.append(
-        String.format(Locale.ROOT, "%02x", b)
-      );
-    }
-
-    return result.toString();
+    return HashUtils.md5Hex(value);
   }
 
   /**

--- a/src/main/java/nfcore/nftest/utils/FileTraversalUtils.java
+++ b/src/main/java/nfcore/nftest/utils/FileTraversalUtils.java
@@ -38,7 +38,7 @@ public final class FileTraversalUtils {
    * @return A list of files found in the directory.
    * @throws IOException If an error occurs while traversing the directory.
    */
-  public static List getAllFilesFromDir(
+  public static List<?> getAllFilesFromDir(
       final String path)
       throws IOException {
     return getAllFilesFromDir(new LinkedHashMap<String, Object>(), path);
@@ -56,7 +56,7 @@ public final class FileTraversalUtils {
    * @throws IllegalArgumentException If {@code outdir} is null, empty, does
    *     not exist, or is not a directory.
    */
-  public static List getAllFilesFromDir(
+  public static List<?> getAllFilesFromDir(
       final LinkedHashMap<String, Object> options,
       final String outdir)
       throws IOException {
@@ -255,8 +255,9 @@ public final class FileTraversalUtils {
    * @param channel the channel output to process
    * @return a flattened list containing only absolute file paths
    */
-  public static List getAllFilesFromChannel(final Object channel) {
-    List result = new ArrayList<>();
+  public static List<String> getAllFilesFromChannel(
+      final Object channel) {
+    List<String> result = new ArrayList<>();
 
     if (channel == null) {
       return result;
@@ -275,7 +276,7 @@ public final class FileTraversalUtils {
    */
   static void flattenAndFilter(
       final Object obj,
-      final List result) {
+      final List<String> result) {
     if (obj == null) {
       return;
     }

--- a/src/main/java/nfcore/nftest/utils/FileTraversalUtils.java
+++ b/src/main/java/nfcore/nftest/utils/FileTraversalUtils.java
@@ -1,0 +1,443 @@
+package nfcore.nftest.utils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility methods for traversing directories and collecting file paths.
+ */
+public final class FileTraversalUtils {
+
+  /**
+   * Prevents instantiation of this utility class.
+   */
+  private FileTraversalUtils() {
+  }
+
+  /**
+   * Retrieves all files from the specified directory using default options.
+   *
+   * @param path The path to the directory to traverse.
+   * @return A list of files found in the directory.
+   * @throws IOException If an error occurs while traversing the directory.
+   */
+  public static List getAllFilesFromDir(
+      final String path)
+      throws IOException {
+    return getAllFilesFromDir(new LinkedHashMap<String, Object>(), path);
+  }
+
+  /**
+   * Retrieves files from an output directory using options provided in a map.
+   *
+   * @param options Options controlling directory traversal and filtering.
+   * @param outdir The root output directory to traverse.
+   * @return A list of matching files or relative paths when {@code relative}
+   *     is enabled.
+   * @throws IOException If an error occurs while traversing the directory or
+   *     reading the ignore patterns file.
+   * @throws IllegalArgumentException If {@code outdir} is null, empty, does
+   *     not exist, or is not a directory.
+   */
+  public static List getAllFilesFromDir(
+      final LinkedHashMap<String, Object> options,
+      final String outdir)
+      throws IOException {
+    if (outdir == null || outdir.isEmpty()) {
+      throw new IllegalArgumentException(
+        "The 'outdir' parameter is required."
+      );
+    }
+    Path dirPath = Paths.get(outdir);
+    if (!Files.exists(dirPath)) {
+      throw new IllegalArgumentException(
+        "The specified path does not exist: " + outdir
+      );
+    }
+
+    if (!Files.isDirectory(dirPath)) {
+      throw new IllegalArgumentException(
+        "The specified path is not a directory: " + outdir
+      );
+    }
+
+    Boolean includeDir = (Boolean) options
+      .getOrDefault("includeDir", false);
+    List<String> ignoreGlobs = (List<String>) options
+      .getOrDefault("ignore", new ArrayList<String>());
+    String ignoreFilePath = (String) options
+      .get("ignoreFile");
+    Boolean relative = (Boolean) options
+      .getOrDefault("relative", false);
+    List<String> includeGlobs = (List<String>) options
+      .getOrDefault("include", Arrays.asList("*", "**/*"));
+
+    List<File> files = getAllFilesFromDir(
+      outdir, includeDir, ignoreGlobs,
+      ignoreFilePath, includeGlobs);
+
+    if (relative) {
+      return getRelativePath(files, outdir);
+    } else {
+      return files;
+    }
+  }
+
+  /**
+   * Recursively retrieves files and optionally directories from an output
+   * directory, applying include and exclude glob patterns.
+   *
+   * @param outdir The root output directory to traverse.
+   * @param includeDir Whether directories should be included in the result.
+   * @param ignoreGlobs Glob patterns identifying files or directories to
+   *     exclude.
+   * @param ignoreFilePath Path to a file containing additional ignore glob
+   *     patterns.
+   * @param includeGlobs Glob patterns identifying files or directories to
+   *     include.
+   * @return A sorted list of matching files and, if enabled, directories.
+   * @throws IOException If an error occurs while traversing the directory or
+   *     reading the ignore patterns file.
+   */
+  public static List<File> getAllFilesFromDir(
+      final String outdir,
+      final boolean includeDir,
+      final List<String> ignoreGlobs,
+      final String ignoreFilePath,
+      final List<String> includeGlobs)
+      throws IOException {
+    List<File> output = new ArrayList<>();
+    Path directory = Paths.get(outdir);
+
+    List<String> allIgnoreGlobs = new ArrayList<>();
+    if (ignoreGlobs != null) {
+      allIgnoreGlobs.addAll(ignoreGlobs);
+    }
+    if (ignoreFilePath != null && !ignoreFilePath.isEmpty()) {
+      allIgnoreGlobs.addAll(readGlobsFromFile(ignoreFilePath));
+    }
+
+    List<PathMatcher> excludeMatchers = new ArrayList<>();
+    for (String glob : allIgnoreGlobs) {
+      excludeMatchers.add(
+        FileSystems.getDefault().getPathMatcher("glob:" + glob)
+      );
+    }
+
+    List<String> allIncludeGlobs = new ArrayList<>();
+    if (includeGlobs != null) {
+      allIncludeGlobs.addAll(includeGlobs);
+    }
+
+    List<PathMatcher> includeMatchers = new ArrayList<>();
+    for (String glob : allIncludeGlobs) {
+      includeMatchers.add(
+        FileSystems.getDefault().getPathMatcher("glob:" + glob)
+      );
+    }
+
+    Files.walkFileTree(
+        directory,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult visitFile(
+              final Path file,
+              final BasicFileAttributes attrs) {
+            if (isIncluded(file) && !isExcluded(file)) {
+              output.add(file.toFile());
+            }
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult preVisitDirectory(
+              final Path dir,
+              final BasicFileAttributes attrs) {
+            Path fileName = dir.getFileName();
+            if (
+                includeDir
+                && isIncluded(dir)
+                && !isExcluded(dir)
+                && fileName != null
+                && !fileName.toString().equals("output")) {
+              output.add(dir.toFile());
+            }
+            return FileVisitResult.CONTINUE;
+          }
+
+          private boolean isExcluded(final Path path) {
+            return excludeMatchers
+              .stream()
+              .anyMatch(matcher -> matcher.matches(directory.relativize(path)));
+          }
+
+          private boolean isIncluded(final Path path) {
+            return includeMatchers
+              .stream()
+              .anyMatch(matcher -> matcher.matches(directory.relativize(path)));
+          }
+        });
+
+    return output
+      .stream()
+      .sorted(Comparator.comparing(File::getPath))
+      .collect(Collectors.toList());
+  }
+
+  /**
+   * Reads glob patterns from a file, ignoring empty lines and
+   * surrounding whitespace.
+   *
+   * @param filePath The path to the file containing glob patterns.
+   * @return A list of glob patterns read from the file.
+   * @throws IOException If an error occurs while reading the file.
+   */
+  static List<String> readGlobsFromFile(
+      final String filePath)
+      throws IOException {
+    List<String> globs = new ArrayList<>();
+    try (BufferedReader reader = Files.newBufferedReader(
+        Paths.get(filePath),
+        StandardCharsets.UTF_8)) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        line = line.trim();
+        if (!line.isEmpty()) {
+          globs.add(line);
+        }
+      }
+    }
+    return globs;
+  }
+
+  /**
+   * Converts a list of file paths to paths relative to the specified base
+   * directory.
+   *
+   * @param filePaths The file paths to convert.
+   * @param baseDir The base directory used to calculate relative paths.
+   * @return A list of paths relative to the specified base directory.
+   */
+  public static List<String> getRelativePath(
+      final List<File> filePaths,
+      final String baseDir) {
+    Path basePath = Paths.get(baseDir).toAbsolutePath().normalize();
+
+    return filePaths
+        .stream()
+        .map(filePath -> {
+          Path path = Paths.get(filePath.toURI()).toAbsolutePath().normalize();
+          return basePath.relativize(path).toString();
+        })
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Get all file paths from a Nextflow channel output.
+   *
+   * @param channel the channel output to process
+   * @return a flattened list containing only absolute file paths
+   */
+  public static List getAllFilesFromChannel(final Object channel) {
+    List result = new ArrayList<>();
+
+    if (channel == null) {
+      return result;
+    }
+
+    flattenAndFilter(channel, result);
+
+    return result;
+  }
+
+  /**
+   * Helper method to recursively flatten nested collections and filter items.
+   *
+   * @param obj The object to recursively flatten and filter.
+   * @param result The list to which matching absolute paths are added.
+   */
+  static void flattenAndFilter(
+      final Object obj,
+      final List result) {
+    if (obj == null) {
+      return;
+    }
+
+    if (obj instanceof Map) {
+      return;
+    }
+
+    if (obj instanceof Iterable) {
+      for (Object item : (Iterable) obj) {
+        flattenAndFilter(item, result);
+      }
+    } else if (obj instanceof String) {
+      String str = (String) obj;
+      if (str.startsWith("/")) {
+        result.add(str);
+      }
+    } else if (obj.getClass().isArray()) {
+      int length = java.lang.reflect.Array.getLength(obj);
+      for (int i = 0; i < length; i++) {
+        flattenAndFilter(java.lang.reflect.Array.get(obj, i), result);
+      }
+    }
+  }
+
+  /**
+   * Lists all files at the given path, returning sorted relative paths.
+   *
+   * @param path The path to list - a local directory or an S3 URI
+   * @return A sorted list of relative file paths under {@code path}
+   * @throws IOException if the path cannot be walked or the AWS CLI fails
+   * @throws InterruptedException if the AWS CLI process is interrupted
+   */
+  public static List<String> getAllFilesFromPath(
+      final String path)
+      throws IOException, InterruptedException {
+    return getAllFilesFromPath(new LinkedHashMap<String, Object>(), path);
+  }
+
+  /**
+   * Lists all files at the given path (local or cloud), returning sorted
+   * relative paths, with filtering options.
+   *
+   * @param options Named options map (Groovy named params)
+   * @param path    The path to list - a local directory or a cloud URI
+   * @return A sorted list of relative file paths under {@code path}
+   * @throws IOException if the path cannot be walked or the AWS CLI fails
+   * @throws InterruptedException if the AWS CLI process is interrupted
+   */
+  public static List<String> getAllFilesFromPath(
+      final LinkedHashMap<String, Object> options,
+      final String path)
+      throws IOException, InterruptedException {
+    if (path == null || path.isEmpty()) {
+      throw new IllegalArgumentException(
+        "The 'path' parameter is required."
+      );
+    }
+
+    List<String> ignoreGlobs =
+        (List<String>) options.getOrDefault(
+          "ignore", new ArrayList<String>()
+        );
+    List<String> includeGlobs =
+        (List<String>) options.getOrDefault(
+          "include", Arrays.asList("**", "*")
+        );
+    Boolean includeDir = (Boolean) options
+      .getOrDefault("includeDir", false);
+    String ignoreFilePath = (String) options.get("ignoreFile");
+    Boolean noSignRequest = (Boolean) options
+      .getOrDefault("noSignRequest", false);
+
+    List<String> allIgnoreGlobs = new ArrayList<>(ignoreGlobs);
+    if (ignoreFilePath != null && !ignoreFilePath.isEmpty()) {
+      allIgnoreGlobs.addAll(readGlobsFromFile(ignoreFilePath));
+    }
+
+    List<PathMatcher> excludeMatchers = new ArrayList<>();
+    for (String glob : allIgnoreGlobs) {
+      if (glob != null && !glob.isEmpty()) {
+        excludeMatchers.add(FileSystems
+          .getDefault()
+          .getPathMatcher("glob:" + glob)
+        );
+      }
+    }
+
+    List<PathMatcher> includeMatchers = new ArrayList<>();
+    for (String glob : includeGlobs) {
+      if (glob != null && !glob.isEmpty()) {
+        includeMatchers.add(FileSystems
+          .getDefault()
+          .getPathMatcher("glob:" + glob)
+        );
+      }
+    }
+
+    if (path.startsWith("s3://")) {
+      return ArchiveDownloader.getAllFilesFromS3ViaCli(
+        path, includeMatchers, excludeMatchers,
+        includeDir, noSignRequest
+      );
+    }
+
+    Path root = Paths.get(path);
+    List<String> files = new ArrayList<>();
+
+    Files.walkFileTree(
+        root,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult visitFile(
+              final Path file,
+              final BasicFileAttributes attrs) {
+            String relative = root.relativize(file).toString();
+            if (relative.isEmpty()) {
+              return FileVisitResult.CONTINUE;
+            }
+            Path relLocal = Paths.get(relative);
+            boolean included =
+                includeMatchers.isEmpty()
+                    || includeMatchers
+                      .stream()
+                      .anyMatch(m -> m.matches(relLocal));
+            boolean excluded = excludeMatchers
+              .stream()
+              .anyMatch(m -> m.matches(relLocal));
+            if (included && !excluded) {
+              files.add(relative);
+            }
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult preVisitDirectory(
+              final Path dir,
+              final BasicFileAttributes attrs) {
+            if (dir.equals(root)) {
+              return FileVisitResult.CONTINUE;
+            }
+            if (includeDir) {
+              String relative = root.relativize(dir).toString();
+              if (!relative.isEmpty()) {
+                Path relLocal = Paths.get(relative);
+                boolean included =
+                    includeMatchers.isEmpty()
+                        || includeMatchers
+                          .stream()
+                          .anyMatch(m -> m.matches(relLocal));
+                boolean excluded = excludeMatchers
+                  .stream()
+                  .anyMatch(m -> m.matches(relLocal));
+                if (included && !excluded) {
+                  files.add(relative);
+                }
+              }
+            }
+            return FileVisitResult.CONTINUE;
+          }
+        });
+
+    return files.stream().sorted().collect(Collectors.toList());
+  }
+}

--- a/src/main/java/nfcore/nftest/utils/HashUtils.java
+++ b/src/main/java/nfcore/nftest/utils/HashUtils.java
@@ -1,12 +1,10 @@
 package nfcore.nftest.utils;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.Locale;
+import java.util.List;
 
 /**
  * Utility methods for computing MD5 hashes.
@@ -25,6 +23,20 @@ public final class HashUtils {
   private static final int BYTE_MASK = 0xff;
 
   /**
+   * Converts a byte to its two-digit lowercase hexadecimal representation.
+   *
+   * @param b The byte to convert.
+   * @return The byte as a two-digit hexadecimal string.
+   */
+  private static String byteToHex(final byte b) {
+    final String hex = Integer.toHexString(BYTE_MASK & b);
+    if (hex.length() == 1) {
+      return "0" + hex;
+    }
+    return hex;
+  }
+
+  /**
    * Computes an MD5 hash of the given string value.
    *
    * @param value The string to hash.
@@ -40,9 +52,7 @@ public final class HashUtils {
 
     final StringBuilder result = new StringBuilder();
     for (final byte b : hash) {
-      result.append(
-        String.format(Locale.ROOT, "%02x", b)
-      );
+      result.append(byteToHex(b));
     }
     return result.toString();
   }
@@ -53,30 +63,22 @@ public final class HashUtils {
    *
    * @param input The list of objects to include in the MD5 calculation.
    * @return The MD5 digest as a hexadecimal string.
-   * @throws UnsupportedEncodingException If UTF-8 encoding is not supported.
+   * @throws NoSuchAlgorithmException If the MD5 algorithm is not available.
    */
-  public static String listToMD5(
-      final ArrayList<Object> input)
-      throws UnsupportedEncodingException {
-    try {
-      MessageDigest md5 = MessageDigest.getInstance("MD5");
-      Iterator<Object> inputIterator = input.iterator();
-      while (inputIterator.hasNext()) {
-        md5.update(inputIterator.next().toString().getBytes("UTF-8"));
-      }
-      byte[] digest = md5.digest();
-
-      StringBuilder hexString = new StringBuilder();
-      for (byte b : digest) {
-        String hex = Integer.toHexString(BYTE_MASK & b);
-        if (hex.length() == 1) {
-          hexString.append('0');
-        }
-        hexString.append(hex);
-      }
-      return hexString.toString();
-    } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException("MD5 algorithm not available", e);
+  public static String listToMD5(final List<?> input)
+      throws NoSuchAlgorithmException {
+    final MessageDigest md5 = MessageDigest.getInstance("MD5");
+    final Iterator<?> inputIterator = input.iterator();
+    while (inputIterator.hasNext()) {
+      final String item = inputIterator.next().toString();
+      md5.update(item.getBytes(StandardCharsets.UTF_8));
     }
+    final byte[] digest = md5.digest();
+
+    final StringBuilder hexString = new StringBuilder();
+    for (final byte b : digest) {
+      hexString.append(byteToHex(b));
+    }
+    return hexString.toString();
   }
 }

--- a/src/main/java/nfcore/nftest/utils/HashUtils.java
+++ b/src/main/java/nfcore/nftest/utils/HashUtils.java
@@ -1,0 +1,82 @@
+package nfcore.nftest.utils;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Locale;
+
+/**
+ * Utility methods for computing MD5 hashes.
+ */
+public final class HashUtils {
+
+  /**
+   * Prevents instantiation of this utility class.
+   */
+  private HashUtils() {
+  }
+
+  /**
+   * Bit mask used to convert a signed byte to its unsigned representation.
+   */
+  private static final int BYTE_MASK = 0xff;
+
+  /**
+   * Computes an MD5 hash of the given string value.
+   *
+   * @param value The string to hash.
+   * @return The MD5 digest as a lowercase hexadecimal string.
+   * @throws NoSuchAlgorithmException If the MD5 algorithm is not available.
+   */
+  public static String md5Hex(final String value)
+      throws NoSuchAlgorithmException {
+    final MessageDigest digest = MessageDigest.getInstance("MD5");
+    final byte[] hash = digest.digest(
+      value.getBytes(StandardCharsets.UTF_8)
+    );
+
+    final StringBuilder result = new StringBuilder();
+    for (final byte b : hash) {
+      result.append(
+        String.format(Locale.ROOT, "%02x", b)
+      );
+    }
+    return result.toString();
+  }
+
+  /**
+   * Computes an MD5 hash from the string representation of each element in
+   * a list.
+   *
+   * @param input The list of objects to include in the MD5 calculation.
+   * @return The MD5 digest as a hexadecimal string.
+   * @throws UnsupportedEncodingException If UTF-8 encoding is not supported.
+   */
+  public static String listToMD5(
+      final ArrayList<Object> input)
+      throws UnsupportedEncodingException {
+    try {
+      MessageDigest md5 = MessageDigest.getInstance("MD5");
+      Iterator<Object> inputIterator = input.iterator();
+      while (inputIterator.hasNext()) {
+        md5.update(inputIterator.next().toString().getBytes("UTF-8"));
+      }
+      byte[] digest = md5.digest();
+
+      StringBuilder hexString = new StringBuilder();
+      for (byte b : digest) {
+        String hex = Integer.toHexString(BYTE_MASK & b);
+        if (hex.length() == 1) {
+          hexString.append('0');
+        }
+        hexString.append(hex);
+      }
+      return hexString.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException("MD5 algorithm not available", e);
+    }
+  }
+}

--- a/src/main/java/nfcore/nftest/utils/Methods.java
+++ b/src/main/java/nfcore/nftest/utils/Methods.java
@@ -2,9 +2,8 @@ package nfcore.nftest.utils;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -204,11 +203,10 @@ public final class Methods {
    *
    * @param input The list of objects to include in the MD5 calculation.
    * @return The MD5 digest as a hexadecimal string.
-   * @throws UnsupportedEncodingException If UTF-8 encoding is not supported.
+   * @throws NoSuchAlgorithmException If the MD5 algorithm is not available.
    */
-  public static String listToMD5(
-      final ArrayList<Object> input)
-      throws UnsupportedEncodingException {
+  public static String listToMD5(final List<?> input)
+      throws NoSuchAlgorithmException {
     return HashUtils.listToMD5(input);
   }
 

--- a/src/main/java/nfcore/nftest/utils/Methods.java
+++ b/src/main/java/nfcore/nftest/utils/Methods.java
@@ -21,7 +21,8 @@ import java.util.TreeMap;
 public final class Methods {
 
   /** Default number of decimal places for CSV double values. */
-  private static final int DEFAULT_CSV_DOUBLE_DIGITS = 6;
+  private static final int DEFAULT_CSV_DOUBLE_DIGITS =
+    CsvUtils.DEFAULT_DOUBLE_DIGITS;
 
   /**
    * Prevents instantiation of this utility class.
@@ -94,7 +95,7 @@ public final class Methods {
    * @return A list of files found in the directory.
    * @throws IOException If an error occurs while traversing the directory.
    */
-  public static List getAllFilesFromDir(
+  public static List<?> getAllFilesFromDir(
       final String path)
       throws IOException {
     return FileTraversalUtils.getAllFilesFromDir(path);
@@ -109,7 +110,7 @@ public final class Methods {
    * @throws IOException If an error occurs while traversing the directory.
    * @throws IllegalArgumentException If {@code outdir} is invalid.
    */
-  public static List getAllFilesFromDir(
+  public static List<?> getAllFilesFromDir(
       final LinkedHashMap<String, Object> options,
       final String outdir)
       throws IOException {
@@ -145,7 +146,8 @@ public final class Methods {
    * @param channel the channel output to process
    * @return a flattened list containing only absolute file paths
    */
-  public static List getAllFilesFromChannel(final Object channel) {
+  public static List<String> getAllFilesFromChannel(
+      final Object channel) {
     return FileTraversalUtils.getAllFilesFromChannel(channel);
   }
 

--- a/src/main/java/nfcore/nftest/utils/Methods.java
+++ b/src/main/java/nfcore/nftest/utils/Methods.java
@@ -1,37 +1,22 @@
 package nfcore.nftest.utils;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystems;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.List;
-import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.HashMap;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
-import java.util.Locale;
-import java.util.stream.Collectors;
-import org.yaml.snakeyaml.Yaml;
 
 /**
- * Utility methods for interacting with files and process output.
+ * Public API for the nft-utils nf-test plugin.
+ *
+ * <p>All methods in this class are registered as Groovy extension methods
+ * via {@code META-INF/nf-test-plugin}. Each method delegates to a
+ * specialized utility class.
  */
 public final class Methods {
 
@@ -44,6 +29,8 @@ public final class Methods {
   private Methods() {
   }
 
+  // ── YAML ──────────────────────────────────────────────────────────────
+
   /**
    * Reads a Version YAML file and returns its contents as a nested map.
    *
@@ -53,84 +40,7 @@ public final class Methods {
    */
   public static Map<String, Map<String, Object>> readYamlFile(
       final String filePath) {
-    Yaml yaml = new Yaml();
-    try (BufferedReader reader = Files.newBufferedReader(
-        Paths.get(filePath),
-        StandardCharsets.UTF_8)) {
-      Map<String, Map<String, Object>> data = yaml.load(reader);
-      return data;
-    } catch (IOException e) {
-      System.err.println("Error reading YAML file: " + e.getMessage());
-      return null;
-    }
-  }
-
-  /**
-   * Resolves a file path or wildcard pattern to a list of matching file paths.
-   *
-   * @param pathPattern The file path or wildcard pattern to resolve.
-   * @return A sorted list of matching absolute file paths.
-   * @throws IOException If the parent directory does not exist, no files match
-   *     the pattern, or an error occurs while accessing the directory.
-   */
-    private static List<String> resolveWildcardPaths(
-      final String pathPattern)
-      throws IOException {
-    // If no wildcard, return single item list
-    if (!pathPattern.contains("*") && !pathPattern.contains("?")) {
-      return Arrays.asList(pathPattern);
-    }
-
-    Path pattern = Paths.get(pathPattern);
-    Path parent = pattern.getParent();
-    Path fileNamePath = pattern.getFileName();
-    if (fileNamePath == null) {
-      throw new IOException(
-        "Invalid path pattern: " + pathPattern
-      );
-    }
-    String fileName = fileNamePath.toString();
-
-    // If parent is null, use current directory
-    if (parent == null) {
-      parent = Paths.get(".");
-    }
-
-    // Check if parent directory exists
-    if (!Files.exists(parent) || !Files.isDirectory(parent)) {
-      throw new IOException(
-        "Parent directory does not exist: "
-        + parent
-      );
-    }
-
-    PathMatcher matcher = FileSystems
-      .getDefault()
-      .getPathMatcher("glob:" + fileName);
-
-    // Find matching files in the parent directory
-    try {
-      List<String> matchingFiles = Files.list(parent)
-          .filter(Files::isRegularFile)
-          .filter(path -> matcher.matches(path.getFileName()))
-          .sorted()
-          .map(path -> path.toAbsolutePath().toString())
-          .collect(Collectors.toList());
-
-      if (matchingFiles.isEmpty()) {
-        throw new IOException(
-          "No files found matching pattern: "
-          + pathPattern
-        );
-      }
-
-      return matchingFiles;
-    } catch (IOException e) {
-      throw new IOException(
-        "Error resolving wildcard pattern "
-        + pathPattern + ": " + e.getMessage()
-      );
-    }
+    return YamlUtils.readYamlFile(filePath);
   }
 
   /**
@@ -142,7 +52,7 @@ public final class Methods {
    */
   public static Map<String, Map<String, Object>> removeNextflowVersion(
       final CharSequence versionFile) {
-    return removeFromYamlMap(versionFile, "Workflow", "Nextflow");
+    return YamlUtils.removeNextflowVersion(versionFile);
   }
 
   /**
@@ -159,53 +69,7 @@ public final class Methods {
       final CharSequence versionFile,
       final String key1,
       final String key2) {
-    String yamlFilePattern = versionFile.toString();
-    Map<String, Map<String, Object>> mergedResult = new TreeMap<>();
-
-    try {
-      // Resolve wildcard patterns if present - now returns all matching files
-      List<String> yamlFilePaths = resolveWildcardPaths(yamlFilePattern);
-
-      for (String yamlFilePath : yamlFilePaths) {
-        Map<String, Map<String, Object>> yamlData = readYamlFile(yamlFilePath);
-
-        if (yamlData != null) {
-          // Process each file's data
-          if (yamlData.containsKey(key1)) {
-            if (key2 == null || key2.isEmpty()) {
-              // Remove the entire key1 entry
-              yamlData.remove(key1);
-            } else {
-              // Remove only the specific key2 from key1
-              yamlData.get(key1).remove(key2);
-            }
-          }
-
-          // Merge the processed data into the result
-          for (
-              Map.Entry<String, Map<String, Object>> entry
-              : yamlData.entrySet()) {
-            String key = entry.getKey();
-            Map<String, Object> value = entry.getValue();
-
-            if (mergedResult.containsKey(key)) {
-              // If key already exists, merge the inner maps
-              mergedResult.get(key).putAll(value);
-            } else {
-              // If key doesn't exist, add it (also sorted)
-              mergedResult.put(key, new TreeMap<>(value));
-            }
-          }
-        }
-      }
-    } catch (IOException e) {
-      System.err.println(
-        "Error resolving file path pattern: " + e.getMessage()
-      );
-      return null;
-    }
-
-    return mergedResult;
+    return YamlUtils.removeFromYamlMap(versionFile, key1, key2);
   }
 
   /**
@@ -218,8 +82,10 @@ public final class Methods {
   public static Map<String, Map<String, Object>> removeFromYamlMap(
       final CharSequence versionFile,
       final String key1) {
-    return removeFromYamlMap(versionFile, key1, null);
+    return YamlUtils.removeFromYamlMap(versionFile, key1);
   }
+
+  // ── FILE TRAVERSAL ────────────────────────────────────────────────────
 
   /**
    * Retrieves all files from the specified directory using default options.
@@ -228,10 +94,10 @@ public final class Methods {
    * @return A list of files found in the directory.
    * @throws IOException If an error occurs while traversing the directory.
    */
-    public static List getAllFilesFromDir(
+  public static List getAllFilesFromDir(
       final String path)
       throws IOException {
-    return getAllFilesFromDir(new LinkedHashMap<String, Object>(), path);
+    return FileTraversalUtils.getAllFilesFromDir(path);
   }
 
   /**
@@ -239,58 +105,15 @@ public final class Methods {
    *
    * @param options Options controlling directory traversal and filtering.
    * @param outdir The root output directory to traverse.
-   * @return A list of matching files or relative paths when {@code relative}
-   *     is enabled.
-   * @throws IOException If an error occurs while traversing the directory or
-   *     reading the ignore patterns file.
-   * @throws IllegalArgumentException If {@code outdir} is null, empty, does
-   *     not exist, or is not a directory.
+   * @return A list of matching files or relative paths.
+   * @throws IOException If an error occurs while traversing the directory.
+   * @throws IllegalArgumentException If {@code outdir} is invalid.
    */
   public static List getAllFilesFromDir(
       final LinkedHashMap<String, Object> options,
       final String outdir)
       throws IOException {
-    if (outdir == null || outdir.isEmpty()) {
-      throw new IllegalArgumentException(
-        "The 'outdir' parameter is required."
-      );
-    }
-    // Check if path exists
-    Path dirPath = Paths.get(outdir);
-    if (!Files.exists(dirPath)) {
-      throw new IllegalArgumentException(
-        "The specified path does not exist: " + outdir
-      );
-    }
-
-    // Check if it's a directory
-    if (!Files.isDirectory(dirPath)) {
-      throw new IllegalArgumentException(
-        "The specified path is not a directory: " + outdir
-      );
-    }
-
-    // Extract optional parameters from the map (use defaults if not provided)
-    Boolean includeDir = (Boolean) options
-      .getOrDefault("includeDir", false);
-    List<String> ignoreGlobs = (List<String>) options
-      .getOrDefault("ignore", new ArrayList<String>());
-    String ignoreFilePath = (String) options
-      .get("ignoreFile");
-    Boolean relative = (Boolean) options
-      .getOrDefault("relative", false);
-    List<String> includeGlobs = (List<String>) options
-      .getOrDefault("include", Arrays.asList("*", "**/*"));
-
-    List<File> files = getAllFilesFromDir(
-      outdir, includeDir, ignoreGlobs,
-      ignoreFilePath, includeGlobs);
-
-    if (relative) {
-      return getRelativePath(files, outdir);
-    } else {
-      return files;
-    }
+    return FileTraversalUtils.getAllFilesFromDir(options, outdir);
   }
 
   /**
@@ -299,15 +122,11 @@ public final class Methods {
    *
    * @param outdir The root output directory to traverse.
    * @param includeDir Whether directories should be included in the result.
-   * @param ignoreGlobs Glob patterns identifying files or directories to
-   *     exclude.
-   * @param ignoreFilePath Path to a file containing additional ignore glob
-   *     patterns.
-   * @param includeGlobs Glob patterns identifying files or directories to
-   *     include.
-   * @return A sorted list of matching files and, if enabled, directories.
-   * @throws IOException If an error occurs while traversing the directory or
-   *     reading the ignore patterns file.
+   * @param ignoreGlobs Glob patterns to exclude.
+   * @param ignoreFilePath Path to a file containing additional ignore patterns.
+   * @param includeGlobs Glob patterns to include.
+   * @return A sorted list of matching files and directories.
+   * @throws IOException If an error occurs while traversing the directory.
    */
   public static List<File> getAllFilesFromDir(
       final String outdir,
@@ -316,109 +135,18 @@ public final class Methods {
       final String ignoreFilePath,
       final List<String> includeGlobs)
       throws IOException {
-    List<File> output = new ArrayList<>();
-    Path directory = Paths.get(outdir);
-
-    List<String> allIgnoreGlobs = new ArrayList<>();
-    if (ignoreGlobs != null) {
-      allIgnoreGlobs.addAll(ignoreGlobs);
-    }
-    if (ignoreFilePath != null && !ignoreFilePath.isEmpty()) {
-      allIgnoreGlobs.addAll(readGlobsFromFile(ignoreFilePath));
-    }
-
-    List<PathMatcher> excludeMatchers = new ArrayList<>();
-    for (String glob : allIgnoreGlobs) {
-      excludeMatchers.add(
-        FileSystems.getDefault().getPathMatcher("glob:" + glob)
-      );
-    }
-
-    List<String> allIncludeGlobs = new ArrayList<>();
-    if (includeGlobs != null) {
-      allIncludeGlobs.addAll(includeGlobs);
-    }
-
-    List<PathMatcher> includeMatchers = new ArrayList<>();
-    for (String glob : allIncludeGlobs) {
-      includeMatchers.add(
-        FileSystems.getDefault().getPathMatcher("glob:" + glob)
-      );
-    }
-
-    Files.walkFileTree(
-        directory,
-        new SimpleFileVisitor<Path>() {
-          @Override
-          public FileVisitResult visitFile(
-              final Path file,
-              final BasicFileAttributes attrs) {
-            if (isIncluded(file) && !isExcluded(file)) {
-              output.add(file.toFile());
-            }
-            return FileVisitResult.CONTINUE;
-          }
-
-          @Override
-          public FileVisitResult preVisitDirectory(
-              final Path dir,
-              final BasicFileAttributes attrs) {
-            Path fileName = dir.getFileName();
-            // Exclude output which is the root output folder from nf-test
-            if (
-                includeDir
-                && isIncluded(dir)
-                && !isExcluded(dir)
-                && fileName != null
-                && !fileName.toString().equals("output")) {
-              output.add(dir.toFile());
-            }
-            return FileVisitResult.CONTINUE;
-          }
-
-          private boolean isExcluded(final Path path) {
-            return excludeMatchers
-              .stream()
-              .anyMatch(matcher -> matcher.matches(directory.relativize(path)));
-          }
-
-          private boolean isIncluded(final Path path) {
-            return includeMatchers
-              .stream()
-              .anyMatch(matcher -> matcher.matches(directory.relativize(path)));
-          }
-        });
-
-    return output
-      .stream()
-      .sorted(Comparator.comparing(File::getPath))
-      .collect(Collectors.toList());
+    return FileTraversalUtils.getAllFilesFromDir(
+      outdir, includeDir, ignoreGlobs, ignoreFilePath, includeGlobs);
   }
 
   /**
-   * Reads glob patterns from a file, ignoring empty lines and
-   * surrounding whitespace.
+   * Get all file paths from a Nextflow channel output.
    *
-   * @param filePath The path to the file containing glob patterns.
-   * @return A list of glob patterns read from the file.
-   * @throws IOException If an error occurs while reading the file.
+   * @param channel the channel output to process
+   * @return a flattened list containing only absolute file paths
    */
-  private static List<String> readGlobsFromFile(
-      final String filePath)
-      throws IOException {
-    List<String> globs = new ArrayList<>();
-    try (BufferedReader reader = Files.newBufferedReader(
-        Paths.get(filePath),
-        StandardCharsets.UTF_8)) {
-      String line;
-      while ((line = reader.readLine()) != null) {
-        line = line.trim();
-        if (!line.isEmpty()) {
-          globs.add(line);
-        }
-      }
-    }
-    return globs;
+  public static List getAllFilesFromChannel(final Object channel) {
+    return FileTraversalUtils.getAllFilesFromChannel(channel);
   }
 
   /**
@@ -427,26 +155,46 @@ public final class Methods {
    *
    * @param filePaths The file paths to convert.
    * @param baseDir The base directory used to calculate relative paths.
-   * @return A list of paths relative to the specified base directory.
+   * @return A list of relative paths.
    */
   public static List<String> getRelativePath(
       final List<File> filePaths,
       final String baseDir) {
-    Path basePath = Paths.get(baseDir).toAbsolutePath().normalize();
-
-    return filePaths
-        .stream()
-        .map(filePath -> {
-          Path path = Paths.get(filePath.toURI()).toAbsolutePath().normalize();
-          return basePath.relativize(path).toString();
-        })
-        .collect(Collectors.toList());
+    return FileTraversalUtils.getRelativePath(filePaths, baseDir);
   }
 
   /**
-   * Bit mask used to convert a signed byte to its unsigned representation.
+   * Lists all files at the given path, returning sorted relative paths.
+   *
+   * @param path The path to list - a local directory or an S3 URI
+   * @return A sorted list of relative file paths
+   * @throws IOException if the path cannot be walked or the AWS CLI fails
+   * @throws InterruptedException if the AWS CLI process is interrupted
    */
-  private static final int BYTE_MASK = 0xff;
+  public static List<String> getAllFilesFromPath(
+      final String path)
+      throws IOException, InterruptedException {
+    return FileTraversalUtils.getAllFilesFromPath(path);
+  }
+
+  /**
+   * Lists all files at the given path (local or cloud), returning sorted
+   * relative paths, with filtering options.
+   *
+   * @param options Named options map (Groovy named params)
+   * @param path    The path to list
+   * @return A sorted list of relative file paths
+   * @throws IOException if the path cannot be walked or the AWS CLI fails
+   * @throws InterruptedException if the AWS CLI process is interrupted
+   */
+  public static List<String> getAllFilesFromPath(
+      final LinkedHashMap<String, Object> options,
+      final String path)
+      throws IOException, InterruptedException {
+    return FileTraversalUtils.getAllFilesFromPath(options, path);
+  }
+
+  // ── HASHING ───────────────────────────────────────────────────────────
 
   /**
    * Computes an MD5 hash from the string representation of each element in
@@ -459,28 +207,10 @@ public final class Methods {
   public static String listToMD5(
       final ArrayList<Object> input)
       throws UnsupportedEncodingException {
-    try {
-      MessageDigest md5 = MessageDigest.getInstance("MD5");
-      Iterator<Object> inputIterator = input.iterator();
-      while (inputIterator.hasNext()) {
-        md5.update(inputIterator.next().toString().getBytes("UTF-8"));
-      }
-      byte[] digest = md5.digest();
-
-      // Convert byte array to hex string
-      StringBuilder hexString = new StringBuilder();
-      for (byte b : digest) {
-        String hex = Integer.toHexString(BYTE_MASK & b);
-        if (hex.length() == 1) {
-          hexString.append('0');
-        }
-        hexString.append(hex);
-      }
-      return hexString.toString();
-    } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException("MD5 algorithm not available", e);
-    }
+    return HashUtils.listToMD5(input);
   }
+
+  // ── nf-core MODULE MANAGEMENT ─────────────────────────────────────────
 
   /**
    * Creates the modules directory and .nf-core.yml configuration file.
@@ -495,8 +225,7 @@ public final class Methods {
    * Installs nf-core modules from a list.
    *
    * @param libDir  An nf-core library initialised by nfcoreInitialise()
-   * @param modules List of module names (strings) or module maps with keys:
-   *  name (required), sha (optional), remote (optional)
+   * @param modules List of module names (strings) or module maps
    */
   public static void nfcoreInstall(final String libDir, final List<?> modules) {
     NfCoreUtils.nfcoreInstall(libDir, modules);
@@ -534,19 +263,17 @@ public final class Methods {
     NfCoreUtils.nfcoreDeleteLibrary(libDir);
   }
 
+  // ── OUTPUT FILTERING ──────────────────────────────────────────────────
+
   /**
    * Filters Nextflow stdout/stderr output to remove variable content that makes
    * snapshots unstable.
-   * This method removes common patterns like timestamps, execution IDs, memory
-   * usage, and other
-   * runtime-specific information to make test snapshots reproducible.
    *
    * @param output The stdout or stderr output (String or List) to filter
-   * @return The filtered output as a List<String> with unstable patterns
-   * removed
+   * @return The filtered output as a List&lt;String&gt;
    */
   public static List<String> filterNextflowOutput(final Object output) {
-    return filterNextflowOutput(output, null, true, false, null, null);
+    return NextflowOutputFilter.filterNextflowOutput(output);
   }
 
   /**
@@ -554,13 +281,12 @@ public final class Methods {
    *
    * @param output The stdout or stderr output (String or List) to filter
    * @param sorted Whether to sort the output lines alphabetically
-   * @return The filtered output as a List<String> with unstable patterns
-   * removed
+   * @return The filtered output as a List&lt;String&gt;
    */
   public static List<String> filterNextflowOutput(
       final Object output,
       final boolean sorted) {
-    return filterNextflowOutput(output, null, sorted, false, null, null);
+    return NextflowOutputFilter.filterNextflowOutput(output, sorted);
   }
 
   /**
@@ -569,146 +295,42 @@ public final class Methods {
    *
    * @param output   The stdout or stderr output (String or List) to filter
    * @param sorted   Whether to sort the output lines alphabetically
-   * @param keepAnsi Whether to keep ANSI escape codes (colors, formatting)
-   * @return The filtered output as a List<String> with unstable patterns
-   * removed
+   * @param keepAnsi Whether to keep ANSI escape codes
+   * @return The filtered output as a List&lt;String&gt;
    */
   public static List<String> filterNextflowOutput(
       final Object output,
       final boolean sorted,
       final boolean keepAnsi) {
-    return filterNextflowOutput(output, null, sorted, keepAnsi, null, null);
+    return NextflowOutputFilter.filterNextflowOutput(output, sorted, keepAnsi);
   }
 
   /**
    * Sanitizes a Nextflow output line by replacing non-deterministic values with
-   * stable placeholders, including usernames, timestamps, hashes, paths, run
-   * names, container engines, and software versions.
+   * stable placeholders.
    *
    * @param line The output line to sanitize.
    * @param capturedRunName The run name captured from the Nextflow launching
-   *     line, or {@code null} if no run name was captured.
-   * @return The sanitized output line with non-deterministic values replaced by
-   *     stable placeholders.
+   *     line, or {@code null}.
+   * @return The sanitized output line.
    */
   public static String filterLinePattern(
       final String line,
       final String capturedRunName) {
-    String filtered = line;
-
-    // Replace username value in patterns like "userName : max"
-    String userName = System.getProperty("user.name");
-    if (userName != null && !userName.isEmpty()) {
-      filtered = filtered.replaceAll(
-        "(userName\\s*:\\s*)" + java.util.regex.Pattern.quote(userName),
-        "$1[USER]");
-    }
-
-    // Remove timestamp patterns
-
-    // ISO 8601 related formats:
-    // YYY-MM-DDTHH:mm:ss
-    // YYY-MM-DD HH:mm:ss
-    // YYY-MM-DD_HH-mm-ss
-    filtered = filtered.replaceAll(
-        "\\d{4}-\\d{2}-\\d{2}[T\\s_]\\d{2}[:-]\\d{2}[:-]\\d{2}"
-        + "(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})?",
-        "[TIMESTAMP]");
-    // US date format: MM/DD/YYY HH:mm:ss
-    filtered = filtered.replaceAll(
-      "\\d{2}/\\d{2}/\\d{4}\\s+\\d{2}:\\d{2}:\\d{2}",
-      "[TIMESTAMP]");
-
-    // Remove Nextflow process execution hashes (format: [xx/yyyyyy])
-    filtered = filtered.replaceAll(
-      "\\[[0-9a-f]{2}/[0-9a-f]{6}\\]",
-      "[NXF_HASH]");
-
-    // Remove NFT_HASH work dir (format: [xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx])
-    filtered = filtered.replaceAll(
-      "\\b[0-9a-f]{30,32}\\b",
-      "[NFT_HASH]");
-
-    // Remove revision hashes (format: revision: abc1234)
-    filtered = filtered.replaceAll(
-      "revision: [0-9a-f]{10}",
-      "revision: [REVISION]");
-
-    // Remove Nextflow version update notifications
-    filtered = filtered.replaceAll(
-      ".*Nextflow\\s+\\d+\\.\\d+\\.\\d+.*is available.*",
-      "");
-    filtered = filtered.replaceAll(
-      ".*Please consider updating your version.*",
-      "");
-
-    // Replace absolute paths with [PATH] placeholder using a more
-    // general approach
-    filtered = filterAbsolutePaths(filtered);
-
-    // Remove run name using captured run name from launching line
-    if (capturedRunName != null) {
-      // Replace bracketed run name: [run_name]
-      filtered = filtered.replace(
-        "[" + capturedRunName + "]",
-        "[RUN_NAME]");
-      // Replace unbracketed run name: run_name
-      filtered = filtered.replace(
-        capturedRunName,
-        "[RUN_NAME]");
-    }
-
-    // Remove containerEngine messages
-    // as it's docker and singularity specific, but not conda
-    filtered = filtered.replaceAll(".*containerEngine.*", "");
-
-    // Replace common reproducibility solutions (ie virtualenv or container)
-    // by [CONTAINER] - All of theses are profiles in nf-core TEMPLATE
-    // I know that none all of these are actually containers, but it's a
-    // good quick approximation
-    filtered = filtered.replaceAll("apptainer", "[CONTAINER]");
-    filtered = filtered.replaceAll("charliecloud", "[CONTAINER]");
-    filtered = filtered.replaceAll("conda", "[CONTAINER]");
-    filtered = filtered.replaceAll("docker", "[CONTAINER]");
-    filtered = filtered.replaceAll("mamba", "[CONTAINER]");
-    filtered = filtered.replaceAll("podman", "[CONTAINER]");
-    filtered = filtered.replaceAll("shifter", "[CONTAINER]");
-    filtered = filtered.replaceAll("singularity", "[CONTAINER]");
-    filtered = filtered.replaceAll("wave", "[CONTAINER]");
-
-    // Replace nf-core pipeline versions (e.g., "nf-core/xxx yyyy")
-    filtered = filtered.replaceAll(
-      "(nf-core/[^\\s]+\\s+)\\d+\\.\\d+(?:\\.\\d+)?[a-zA-Z]*",
-      "$1[VERSION]");
-
-    // Replace NEXTFLOW versions
-    filtered = filtered.replaceAll(
-      "N E X T F L O W  ~  version \\d+\\.\\d+\\.\\d+(-edge)?",
-      "N E X T F L O W  ~  version [VERSION]");
-
-    return filtered;
+    return NextflowOutputFilter.filterLinePattern(line, capturedRunName);
   }
 
   /**
    * Filters Nextflow stdout/stderr output with custom patterns, optional
    * sorting, and ANSI code handling.
    *
-   * @param output             The stdout or stderr output (String or List) to
-   *                           filter
-   * @param additionalPatterns List of additional regex patterns to remove from
-   *                           the output
-   * @param sorted             Whether to sort the output lines alphabetically
-   * @param keepAnsi           Whether to keep ANSI escape codes (colors,
-   *                           formatting)
-   * @param ignore             List of strings to filter out from the output
-   *                           (lines containing any of these strings will be
-   *                           removed)
-   * @param include            List of strings to include in the output (only
-   *                           lines containing at least one of these strings
-   *                           will be kept). If null or empty, all lines are
-   *                           considered for inclusion.
-   * @return The filtered output as a List<String> with unstable patterns
-   * removed
+   * @param output             The output to filter
+   * @param additionalPatterns Additional regex patterns to remove
+   * @param sorted             Whether to sort output lines
+   * @param keepAnsi           Whether to keep ANSI codes
+   * @param ignore             Strings to filter out
+   * @param include            Strings to include
+   * @return The filtered output as a List&lt;String&gt;
    */
   public static List<String> filterNextflowOutput(
       final Object output,
@@ -717,326 +339,38 @@ public final class Methods {
       final boolean keepAnsi,
       final List<String> ignore,
       final List<String> include) {
-    if (output == null) {
-      return new ArrayList<>();
-    }
-
-    List<String> outputLines;
-    if (output instanceof List) {
-      // Handle workflow.stdout and workflow.stderr which are Lists
-      List<?> outputList = (List<?>) output;
-      if (outputList.isEmpty()) {
-        return new ArrayList<>();
-      }
-      outputLines = outputList.stream()
-          .map(Object::toString)
-          .collect(Collectors.toList());
-    } else if (output instanceof String) {
-      String outputString = (String) output;
-      if (outputString.isEmpty()) {
-        return new ArrayList<>();
-      }
-      // Split string into lines
-      outputLines = Arrays.asList(outputString.split("\n"));
-    } else {
-      // Convert any other type to string and split into lines
-      String outputString = output.toString();
-      outputLines = Arrays.asList(outputString.split("\n"));
-    }
-
-    // Filter each line
-    List<String> filteredLines = new ArrayList<>();
-    String capturedRunName = null;
-
-    for (String line : outputLines) {
-      String filtered = line;
-
-      // Filter out lines containing any of the ignore strings
-      if (ignore != null && !ignore.isEmpty()) {
-        boolean shouldIgnore = false;
-        for (String ignoreString : ignore) {
-          if (filtered.contains(ignoreString)) {
-            shouldIgnore = true;
-            break;
-          }
-        }
-        if (shouldIgnore) {
-          continue; // Skip this line
-        }
-      }
-
-      // Filter to include only lines containing any of the include strings
-      if (include != null && !include.isEmpty()) {
-        boolean shouldInclude = false;
-        for (String includeString : include) {
-          if (filtered.contains(includeString)) {
-            shouldInclude = true;
-            break;
-          }
-        }
-        if (!shouldInclude) {
-          continue; // Skip this line
-        }
-      }
-
-      // Strip ANSI escape codes unless keepAnsi is true
-      // (colors, formatting, etc.)
-      if (!keepAnsi) {
-        filtered = filtered.replaceAll(
-          "\\x1B\\[[0-9;]*[A-Za-z]", "");
-      }
-
-      // Capture run name from launching line
-      if (
-          capturedRunName == null
-          && filtered.contains("Launching")
-          && filtered.contains("[")
-          && filtered.contains("]")) {
-        java.util.regex.Pattern runNamePattern =
-          java.util.regex.Pattern.compile("\\[([^\\]]+)\\]");
-        java.util.regex.Matcher matcher = runNamePattern.matcher(filtered);
-        if (matcher.find()) {
-          capturedRunName = matcher.group(1);
-        }
-      }
-
-      filtered = filterLinePattern(filtered, capturedRunName);
-
-      // Only add non-empty lines (filter out empty lines)
-      if (!filtered.trim().isEmpty()) {
-        filteredLines.add(filtered);
-      }
-    }
-
-    // Sort and remove duplicates if requested
-    if (sorted) {
-      // Separate lines that should be sorted from those that
-      // should preserve order
-      List<String> sortableLines = new ArrayList<>();
-      List<String> preserveOrderLines = new ArrayList<>();
-
-      for (String line : filteredLines) {
-        if (line.contains("Staging foreign file")
-            || line.contains("Submitted process")
-            || line.startsWith("Creating env using conda:")
-            || line.startsWith("Pulling Singularity image")
-            || line.startsWith("ERROR ~")
-            || line.startsWith("WARN:")
-            || (
-              line.contains("Check ")
-              && line.contains(" file for details")
-            )) {
-          sortableLines.add(line);
-        } else {
-          preserveOrderLines.add(line);
-        }
-      }
-
-      // Sort only the sortable lines
-      Collections.sort(sortableLines);
-
-      // Combine lists: preserve-order lines first, then sorted lines
-      List<String> combinedLines = new ArrayList<>();
-      combinedLines.addAll(preserveOrderLines);
-      combinedLines.addAll(sortableLines);
-
-      // Remove duplicates while preserving the new order
-      List<String> uniqueLines = new ArrayList<>();
-      String lastLine = null;
-      for (String line : combinedLines) {
-        if (!line.equals(lastLine)) {
-          uniqueLines.add(line);
-          lastLine = line;
-        }
-      }
-      filteredLines = uniqueLines;
-    }
-
-    return filteredLines;
+    return NextflowOutputFilter.filterNextflowOutput(
+      output, additionalPatterns, sorted, keepAnsi, ignore, include);
   }
 
   /**
    * Filters Nextflow stdout/stderr output with custom patterns.
-   * This overloaded method allows specifying additional patterns to filter.
    *
-   * @param output             The stdout or stderr output (String or List) to
-   *                           filter
-   * @param additionalPatterns List of additional regex patterns to remove from
-   *                           the output
-   * @return The filtered output as a List<String> with unstable patterns
-   * removed
+   * @param output             The output to filter
+   * @param additionalPatterns Additional regex patterns to remove
+   * @return The filtered output as a List&lt;String&gt;
    */
   public static List<String> filterNextflowOutput(
       final Object output,
       final List<String> additionalPatterns) {
-    return filterNextflowOutput(
-      output, additionalPatterns,
-      true, false, null, null
-    );
+    return NextflowOutputFilter.filterNextflowOutput(
+      output, additionalPatterns);
   }
 
   /**
-   * Filters Nextflow stdout/stderr output using Groovy's named parameter
-   * syntax.
+   * Filters Nextflow output using Groovy's named parameter syntax.
    *
-   * This allows calling: filterNextflowOutput(output, sorted: false, keepAnsi:
-   * true, ignore: ["Staging foreign file"], include: ["ERROR", "WARN"])
-   *
-   * @param output  The stdout or stderr output (String or List) to filter
-   * @param options Map containing filtering options (automatically created by
-   *                Groovy named params):
-   *                - additionalPatterns: List<String> of additional regex
-   *                patterns (optional)
-   *                - sorted: Boolean whether to sort the output (default: true)
-   *                - keepAnsi: Boolean whether to keep ANSI codes (default:
-   *                false)
-   *                - ignore: List<String> of strings to filter out (lines
-   *                containing any of these strings will be removed) (optional)
-   *                - include: List<String> of strings to include (only lines
-   *                containing at least one of these strings will be kept)
-   *                (optional)
-   * @return The filtered output as a List<String> with unstable patterns
-   * removed
+   * @param options LinkedHashMap of named options (Groovy named params)
+   * @param output  The output to filter
+   * @return The filtered output as a List&lt;String&gt;
    */
-
-  // Handle Groovy named parameters: filterNextflowOutput(output, keepAnsi:
-  // true)
-  // Groovy converts this to: filterNextflowOutput([keepAnsi: true], output)
   public static List<String> filterNextflowOutput(
       final LinkedHashMap<String, Object> options,
       final Object output) {
-
-    final Map<String, Object> optionsFixed;
-    if (options == null) {
-      optionsFixed = new HashMap<>();
-    } else {
-      optionsFixed = options;
-    }
-
-    // Extract options with defaults
-    List<String> additionalPatterns = (List<String>) optionsFixed
-      .get("additionalPatterns");
-    Boolean sorted = (Boolean) optionsFixed.get("sorted");
-    Boolean keepAnsi = (Boolean) optionsFixed.get("keepAnsi");
-    List<String> ignore = (List<String>) optionsFixed.get("ignore");
-    List<String> include = (List<String>) optionsFixed.get("include");
-
-    // Apply defaults
-    if (sorted == null) {
-      sorted = true;
-    }
-    if (keepAnsi == null) {
-      keepAnsi = false;
-    }
-    return filterNextflowOutput(
-      output, additionalPatterns,
-      sorted, keepAnsi, ignore, include
-    );
+    return NextflowOutputFilter.filterNextflowOutput(options, output);
   }
 
-  /**
-   * Filters Nextflow output using options provided in a map, applying default
-   * values for unspecified options.
-   *
-   * @param output The Nextflow output to filter.
-   * @param options The filtering options, or {@code null} to use defaults.
-   * @return A list of filtered output lines.
-   */
-  public static List<String> filterNextflowOutput(
-      final Object output,
-      final Map<String, Object> options) {
-
-    final Map<String, Object> optionsFixed;
-    if (options == null) {
-      optionsFixed = new HashMap<>();
-    } else {
-      optionsFixed = options;
-    }
-
-    // Extract options with defaults
-    List<String> additionalPatterns = (List<String>) optionsFixed
-      .get("additionalPatterns");
-    Boolean sorted = (Boolean) optionsFixed.get("sorted");
-    Boolean keepAnsi = (Boolean) optionsFixed.get("keepAnsi");
-    List<String> ignore = (List<String>) optionsFixed.get("ignore");
-    List<String> include = (List<String>) optionsFixed.get("include");
-
-    // Apply defaults
-    if (sorted == null) {
-      sorted = true;
-    }
-    if (keepAnsi == null) {
-      keepAnsi = false;
-    }
-    return filterNextflowOutput(
-      output, additionalPatterns,
-      sorted, keepAnsi, ignore, include
-    );
-  }
-
-  /**
-   * Filters absolute paths in the given text and replaces them with [PATH]
-   * placeholder.
-   *
-   * @param text The text to filter
-   * @return The filtered text with various directory paths replaced with [PATH]
-   */
-  private static String filterAbsolutePaths(final String text) {
-    String filtered = text;
-
-    // Collect all paths to replace, then sort by length (longest first)
-    // This ensures more specific paths are replaced before their parent paths
-    List<String> pathsToReplace = new ArrayList<>();
-
-    // Get the current working directory
-    String workingDir = System.getProperty("user.dir");
-    if (workingDir != null) {
-      pathsToReplace.add(workingDir);
-    }
-
-    // Check for various environment variables
-    String[] envVars = {
-        "HOME",
-        "NFT_WORKDIR",
-        "NXF_CACHE_DIR",
-        "NXF_CONDA_CACHEDIR",
-        "NXF_HOME",
-        "NXF_SINGULARITY_CACHEDIR",
-        "NXF_SINGULARITY_LIBRARYDIR",
-        "NXF_TEMP",
-        "NXF_WORK"
-    };
-
-    for (String envVar : envVars) {
-      String envValue = System.getenv(envVar);
-      if (envValue != null && !envValue.isEmpty() && !envValue.equals("~")) {
-        pathsToReplace.add(envValue);
-      }
-    }
-
-    // Handle default NXF_HOME case: if NXF_HOME is null, Nextflow uses
-    // $HOME/.nextflow
-    String nxfHome = System.getenv("NXF_HOME");
-    if (nxfHome == null || nxfHome.isEmpty()) {
-      String home = System.getProperty("user.home");
-      if (home != null && !home.isEmpty() && !home.equals("~")) {
-        pathsToReplace.add(home + "/.nextflow");
-      }
-    }
-
-    // Remove duplicates and sort paths by length to avoid partial replacements
-    pathsToReplace = pathsToReplace.stream()
-        .distinct()
-        .sorted((a, b) -> Integer.compare(b.length(), a.length()))
-        .collect(Collectors.toList());
-
-    // Replace all paths with [PATH] in order of longest first
-    for (String path : pathsToReplace) {
-      filtered = filtered.replace(path, "[PATH]");
-    }
-
-    return filtered;
-  }
+  // ── OUTPUT SANITIZATION ───────────────────────────────────────────────
 
   /**
    * Sanitizes the output channel using default sanitization options.
@@ -1062,6 +396,8 @@ public final class Methods {
     return OutputSanitizer.sanitizeOutput(options, channel);
   }
 
+  // ── CSV ───────────────────────────────────────────────────────────────
+
   /**
    * Normalizes a CSV file and returns its canonical representation.
    *
@@ -1084,245 +420,11 @@ public final class Methods {
     return normalizeCsv(path, DEFAULT_CSV_DOUBLE_DIGITS);
   }
 
-  /**
-   * Download a tar archive and extract it in the given destination directory.
-   * The file is streamed directly with `curl` into `tar` via a pipe.
-   * The compression type must be provided if applicable.
-   * Uses safe single-quoting for the URL and destination path.
-   *
-   * @param urlString   the URL to fetch
-   * @param destPath    directory to extract the tarball into
-   * @param compression compression type: tar, gzip, gz, bzip2, bz2, xz, lz4,
-   *                    lzma, lzop, zstd
-   *                    or any of these prefixed with "tar." or "t"
-   * @throws IOException on failure
-   */
-  private static void curlAndUntar(
-      final String urlString,
-      final String destPath,
-      final String compression)
-      throws IOException {
-    Path destDir = Paths.get(destPath);
-    Files.createDirectories(destDir);
-
-    String escUrl = Utils.shellEscape(urlString);
-    String escDest = Utils.shellEscape(destPath);
-    String cmd = "curl -L --retry 5 " + escUrl
-      + " | tar xaf - -C " + escDest;
-    String tarExt = compression;
-
-    // Convert tarExt name to tar option
-    if (tarExt != null && !tarExt.equals("tar")) {
-      // Remove leading "tar." or "t" if present
-      if (tarExt.startsWith("tar.")) {
-        tarExt = tarExt.substring("tar.".length());
-      } else if (tarExt.startsWith("t")) {
-        tarExt = tarExt.substring("t".length());
-      }
-
-      if (tarExt.equals("gzip") || tarExt.equals("gz")) {
-        tarExt = "gzip";
-      } else if (tarExt.equals("bzip2") || tarExt.equals("bz2")) {
-        tarExt = "bzip2";
-      } else if (tarExt.equals("xz")) {
-        tarExt = "xz";
-      } else if (tarExt.equals("lz4")) {
-        tarExt = "lz4";
-      } else if (tarExt.equals("lzma")) {
-        tarExt = "lzma";
-      } else if (tarExt.equals("lzop")) {
-        tarExt = "lzop";
-      } else if (tarExt.equals("zstd") || tarExt.equals("zst")) {
-        tarExt = "zstd";
-      } else {
-        throw new IllegalArgumentException(
-          "Unsupported compression type: " + tarExt
-        );
-      }
-      cmd += " --" + tarExt;
-    }
-
-    ProcessBuilder pb = new ProcessBuilder("sh", "-c", cmd);
-    try {
-      Utils.ProcessResult result = Utils.runProcess(pb);
-      if (result.getExitCode() != 0) {
-        System.err
-            .println(
-              "Error downloading and extracting file "
-              + urlString + ": exit code "
-              + result.getExitCode() + "\n"
-            );
-        System.out.println("Bash command: \n" + cmd);
-        System.err.println("command output: \n");
-        System.err.println(result.getStderr());
-      } else {
-        System.out.println(
-          "Successfully downloaded and extracted file: "
-          + urlString
-        );
-      }
-    } catch (IOException | InterruptedException e) {
-      System.err.println(
-        "Error downloading and extracting file "
-        + urlString + ": " + e.getMessage()
-      );
-      if (e instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-      }
-    }
-  }
-
-  /**
-   * Download a zip file and extract it in the given destination directory.
-   * The file is first downloaded with `curl` to a temporary file, then we
-   * call `unzip` and delete the temporary file.
-   *
-   * @param urlString the URL to fetch
-   * @param destPath  directory to extract the zip into
-   * @throws IOException on failure
-   */
-  private static void curlAndUnzip(
-      final String urlString,
-      final String destPath)
-      throws IOException {
-    Path destDir = Paths.get(destPath);
-    Files.createDirectories(destDir);
-
-    // Create a temporary file in the destination directory for the
-    // downloaded zip
-    Path tempFile = Files.createTempFile(destDir, "download", ".zip");
-
-    // Run curl
-    ProcessBuilder pb = new ProcessBuilder(
-        "curl",
-        "-L",
-        "--retry",
-        "5",
-        "-o",
-        tempFile.toString(),
-        urlString);
-
-    try {
-      Utils.ProcessResult result = Utils.runProcess(pb);
-      if (result.getExitCode() != 0) {
-        System.err.println(
-          "Error downloading file " + urlString
-          + ": exit code " + result.getExitCode() + "\n"
-        );
-        System.out.println("Command: " + String.join(" ", pb.command()));
-        System.err.println("command output: \n");
-        System.err.println(result.getStderr());
-        return;
-      }
-      // Run unzip
-      pb = new ProcessBuilder(
-          "unzip",
-          "-o",
-          tempFile.toString(),
-          "-d",
-          destPath);
-      result = Utils.runProcess(pb);
-      if (result.getExitCode() != 0) {
-        System.err.println(
-          "Error extracting zip " + tempFile
-          + ": exit code " + result.getExitCode() + "\n"
-        );
-        System.out.println("Command: " + String.join(" ", pb.command()));
-        System.err.println("command output: \n");
-        System.err.println(result.getStderr());
-      } else {
-        System.out.println(
-          "Successfully downloaded and extracted file: "
-          + urlString
-        );
-      }
-    } catch (IOException | InterruptedException e) {
-      System.err.println(
-        "Error downloading and extracting file "
-        + urlString + ": " + e.getMessage()
-      );
-      if (e instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-      }
-    } finally {
-      try {
-        Files.deleteIfExists(tempFile);
-      } catch (IOException e) {
-        // Do not fail the operation if temp file cleanup fails; just log it
-        System.err.println(
-          "Warning: failed to delete temporary file "
-          + tempFile + ": " + e.getMessage()
-        );
-      }
-    }
-  }
-
-  /**
-   * Get all file paths from a Nextflow channel output.
-   *
-   * This method collects, flattens, and filters a channel to return only
-   * absolute file paths (strings starting with "/").
-   * Maps and non-absolute paths are filtered out.
-   *
-   * @param channel the channel output to process (typically a Groovy
-   * collection)
-   * @return a flattened list containing only absolute file paths
-   */
-  public static List getAllFilesFromChannel(final Object channel) {
-    List result = new ArrayList<>();
-
-    if (channel == null) {
-      return result;
-    }
-
-    // Flatten and filter the channel
-    flattenAndFilter(channel, result);
-
-    return result;
-  }
-
-  /**
-   * Helper method to recursively flatten nested collections and filter items.
-   * Keeps only String items that start with "/" (absolute paths), excludes
-   * Maps.
-   *
-   * @param obj The object to recursively flatten and filter.
-   * @param result The list to which matching absolute paths are added.
-   */
-  private static void flattenAndFilter(
-      final Object obj,
-      final List result) {
-    if (obj == null) {
-      return;
-    }
-
-    // Skip Maps
-    if (obj instanceof Map) {
-      return;
-    }
-
-    // If it's a collection/iterable, recursively process each element
-    if (obj instanceof Iterable) {
-      for (Object item : (Iterable) obj) {
-        flattenAndFilter(item, result);
-      }
-    } else if (obj instanceof String) { // For strings
-      String str = (String) obj;
-      if (str.startsWith("/")) {
-        result.add(str);
-      }
-    } else if (obj.getClass().isArray()) { // For arrays
-      int length = java.lang.reflect.Array.getLength(obj);
-      for (int i = 0; i < length; i++) {
-        flattenAndFilter(java.lang.reflect.Array.get(obj, i), result);
-      }
-    }
-  }
+  // ── ARCHIVE DOWNLOADING ───────────────────────────────────────────────
 
   /**
    * Download an archive and extract it in the given destination directory.
-   * Dispatches to `curlAndUnzip` for ZIP files and to `curlAndUntar` for
-   * tar archives based on the URL's file extension.
+   * Dispatches based on the URL's file extension.
    *
    * @param urlString the URL to fetch
    * @param destPath  directory to extract the archive into
@@ -1332,431 +434,16 @@ public final class Methods {
       final String urlString,
       final String destPath)
       throws IOException {
-    String lower = Utils.getURLFileName(urlString);
-
-    if (lower.endsWith(".zip")) {
-      curlAndUnzip(urlString, destPath);
-      return;
-    }
-
-    for (String suffix : new String[] {
-        "gz", "bz2", "xz", "lz4", "lzma", "lzop", "zst", "zstd"
-      }) {
-      if (lower.endsWith(".tar." + suffix) || lower.endsWith(".t" + suffix)) {
-        curlAndUntar(urlString, destPath, suffix);
-        return;
-      }
-    }
-
-    if (lower.endsWith(".tar")) {
-      curlAndUntar(urlString, destPath, null);
-      return;
-    }
-
-    throw new IllegalArgumentException(
-      "Unsupported archive type in URL: " + urlString
-    );
-  }
-
-  /**
-   * Lists all files at the given path, returning sorted relative paths.
-   *
-   * <p>Supports local paths and S3 URIs. S3 URIs are listed via the AWS CLI.
-   *
-   * @param path The path to list – a local directory or an S3 URI
-   *             (e.g. {@code "s3://my-bucket/results/"})
-   * @return A sorted list of relative file paths under {@code path}
-   * @throws IOException if the path cannot be walked or the AWS CLI fails
-   * @throws InterruptedException if the AWS CLI process is interrupted
-   */
-  public static List<String> getAllFilesFromPath(
-      final String path)
-      throws IOException, InterruptedException {
-    return getAllFilesFromPath(new LinkedHashMap<String, Object>(), path);
-  }
-
-  /**
-   * Lists all files at the given path (local or cloud), returning sorted
-   * relative paths, with filtering options. Uses Groovy named-parameter
-   * syntax:
-   * {@code getAllFilesFromPath(path, ignore: ['*.log'], include: ['**'])}
-   *
-   * <p>Supported options:
-   * <ul>
-   *   <li>{@code ignore} – {@code List<String>} of glob patterns to exclude
-   *       (matched against the relative path, e.g.
-   *       {@code ['pipeline_info/**']})</li>
-   *   <li>{@code include} – {@code List<String>} of glob patterns to include
-   *       (default: {@code ["**", "*"]})</li>
-   *   <li>{@code includeDir} – {@code Boolean} also emit directory entries
-   *       (default: {@code false})</li>
-   *   <li>{@code ignoreFile} – {@code String} path to a local file whose lines
-   *       are treated as additional ignore globs
-   *       (e.g. {@code ".nftignore"})</li>
-   *   <li>{@code noSignRequest} – {@code Boolean} pass to the AWS CLI
-   *       {@code --no-sign-request} when listing a public S3 bucket without
-   *       credentials (default: {@code false})</li>
-   * </ul>
-   *
-   * @param options Named options map (automatically created by Groovy named
-   * params)
-   * @param path    The path to list – a local directory or a cloud URI
-   * @return A sorted list of relative file paths under {@code path}
-   * @throws IOException if the path cannot be walked or the AWS CLI fails
-   * @throws InterruptedException if the AWS CLI process is interrupted
-   */
-  public static List<String> getAllFilesFromPath(
-      final LinkedHashMap<String, Object> options,
-      final String path)
-      throws IOException, InterruptedException {
-    if (path == null || path.isEmpty()) {
-      throw new IllegalArgumentException(
-        "The 'path' parameter is required."
-      );
-    }
-
-    List<String> ignoreGlobs =
-        (List<String>) options.getOrDefault(
-          "ignore", new ArrayList<String>()
-        );
-    List<String> includeGlobs =
-        (List<String>) options.getOrDefault(
-          "include", Arrays.asList("**", "*")
-        );
-    Boolean includeDir = (Boolean) options
-      .getOrDefault("includeDir", false);
-    String ignoreFilePath = (String) options.get("ignoreFile");
-    Boolean noSignRequest = (Boolean) options
-      .getOrDefault("noSignRequest", false);
-
-    List<String> allIgnoreGlobs = new ArrayList<>(ignoreGlobs);
-    if (ignoreFilePath != null && !ignoreFilePath.isEmpty()) {
-      allIgnoreGlobs.addAll(readGlobsFromFile(ignoreFilePath));
-    }
-
-    List<PathMatcher> excludeMatchers = new ArrayList<>();
-    for (String glob : allIgnoreGlobs) {
-      if (glob != null && !glob.isEmpty()) {
-        excludeMatchers.add(FileSystems
-          .getDefault()
-          .getPathMatcher("glob:" + glob)
-        );
-      }
-    }
-
-    List<PathMatcher> includeMatchers = new ArrayList<>();
-    for (String glob : includeGlobs) {
-      if (glob != null && !glob.isEmpty()) {
-        includeMatchers.add(FileSystems
-          .getDefault()
-          .getPathMatcher("glob:" + glob)
-        );
-      }
-    }
-
-    if (path.startsWith("s3://")) {
-      return getAllFilesFromS3ViaCli(
-        path, includeMatchers, excludeMatchers,
-        includeDir, noSignRequest
-      );
-    }
-
-    Path root = Paths.get(path);
-    List<String> files = new ArrayList<>();
-
-    Files.walkFileTree(
-        root,
-        new SimpleFileVisitor<Path>() {
-          @Override
-          public FileVisitResult visitFile(
-              final Path file,
-              final BasicFileAttributes attrs) {
-            String relative = root.relativize(file).toString();
-            if (relative.isEmpty()) {
-              return FileVisitResult.CONTINUE;
-            }
-            Path relLocal = Paths.get(relative);
-            boolean included =
-                includeMatchers.isEmpty()
-                    || includeMatchers
-                      .stream()
-                      .anyMatch(m -> m.matches(relLocal));
-            boolean excluded = excludeMatchers
-              .stream()
-              .anyMatch(m -> m.matches(relLocal));
-            if (included && !excluded) {
-              files.add(relative);
-            }
-            return FileVisitResult.CONTINUE;
-          }
-
-          @Override
-          public FileVisitResult preVisitDirectory(
-              final Path dir,
-              final BasicFileAttributes attrs) {
-            if (dir.equals(root)) {
-              return FileVisitResult.CONTINUE;
-            }
-            if (includeDir) {
-              String relative = root.relativize(dir).toString();
-              if (!relative.isEmpty()) {
-                Path relLocal = Paths.get(relative);
-                boolean included =
-                    includeMatchers.isEmpty()
-                        || includeMatchers
-                          .stream()
-                          .anyMatch(m -> m.matches(relLocal));
-                boolean excluded = excludeMatchers
-                  .stream()
-                  .anyMatch(m -> m.matches(relLocal));
-                if (included && !excluded) {
-                  files.add(relative);
-                }
-              }
-            }
-            return FileVisitResult.CONTINUE;
-          }
-        });
-
-    return files.stream().sorted().collect(Collectors.toList());
-  }
-
-  /**
-   * Number of fields expected in an AWS S3 CLI listing line.
-   */
-  private static final int AWS_S3_LIST_FIELDS = 4;
-
-  /**
-   * Index of the object key in an AWS S3 CLI listing line.
-   */
-  private static final int AWS_S3_KEY_INDEX = 3;
-
-  /**
-   * Lists files under an S3 prefix using the AWS CLI
-   * ({@code aws s3 ls --recursive}).
-   *
-   * It applies the same include/exclude glob filtering used by the local
-   * walk. S3 key suffixes ending in {@code /} are treated as directory
-   * markers and emitted only when {@code includeDir} is {@code true}.
-   *
-   * @param s3Path The S3 path or prefix to list.
-   * @param includeMatchers Path matchers for files to include.
-   * @param excludeMatchers Path matchers for files to exclude.
-   * @param includeDir Whether directory markers should be included in the
-   * results.
-   * @param noSignRequest Whether to use the AWS CLI {@code --no-sign-request}
-   * option.
-   *
-   * @return A sorted list of S3 object keys matching the include and exclude
-   * filters.
-   * @throws IOException If an I/O error occurs while executing the AWS CLI or
-   *     reading its output.
-   * @throws InterruptedException If the current thread is interrupted while
-   *     waiting for the AWS CLI process to complete.
-   */
-  private static List<String> getAllFilesFromS3ViaCli(
-      final String s3Path,
-      final List<PathMatcher> includeMatchers,
-      final List<PathMatcher> excludeMatchers,
-      final boolean includeDir,
-      final boolean noSignRequest)
-      throws IOException, InterruptedException {
-
-    String normalizedPath = s3Path;
-    if (!s3Path.endsWith("/")) {
-      normalizedPath += "/";
-    }
-    String bucketAndPrefix = normalizedPath.substring("s3://".length());
-    int firstSlash = bucketAndPrefix.indexOf('/');
-    String prefix;
-    if (firstSlash >= 0) {
-      prefix = bucketAndPrefix.substring(firstSlash + 1);
-    } else {
-      prefix = "";
-    }
-
-    List<String> cmd = new ArrayList<>(
-      Arrays.asList("aws", "s3", "ls", "--recursive")
-    );
-    if (noSignRequest) {
-      cmd.add("--no-sign-request");
-    }
-    cmd.add(normalizedPath);
-
-    ProcessBuilder pb = new ProcessBuilder(cmd);
-    pb.redirectErrorStream(false);
-    Process process = pb.start();
-
-    List<String> files = new ArrayList<>();
-    try (BufferedReader reader = new BufferedReader(
-        new InputStreamReader(
-          process.getInputStream(),
-          StandardCharsets.UTF_8
-        )
-    )) {
-      String line;
-      while ((line = reader.readLine()) != null) {
-        // Output format: "2024-01-01 12:00:00 12345 prefix/path/to/file.txt"
-        String[] parts = line.trim().split("\\s+", AWS_S3_LIST_FIELDS);
-        if (parts.length < AWS_S3_LIST_FIELDS) {
-          continue;
-        }
-
-        String fullKey = parts[AWS_S3_KEY_INDEX];
-        String relativePath;
-        if (!prefix.isEmpty() && fullKey.startsWith(prefix)) {
-          relativePath = fullKey.substring(prefix.length());
-        } else {
-          relativePath = fullKey;
-        }
-
-        if (relativePath.isEmpty()) {
-          continue;
-        }
-
-        boolean isDir = relativePath.endsWith("/");
-        if (isDir && !includeDir) {
-          continue;
-        }
-
-        final String pathString;
-        if (isDir) {
-          pathString = relativePath.substring(0, relativePath.length() - 1);
-        } else {
-          pathString = relativePath;
-        }
-        Path relPath = Paths.get(pathString);
-        boolean included = includeMatchers.isEmpty()
-            || includeMatchers.stream().anyMatch(m -> m.matches(relPath));
-        boolean excluded = excludeMatchers
-          .stream()
-          .anyMatch(m -> m.matches(relPath));
-        if (included && !excluded) {
-          files.add(relativePath);
-        }
-      }
-    }
-
-    int exitCode = process.waitFor();
-    if (exitCode != 0) {
-      throw new IOException(
-          "AWS CLI returned exit code " + exitCode
-          + " when listing: " + normalizedPath);
-    }
-
-    return files.stream().sorted().collect(Collectors.toList());
-  }
-
-  /**
-   * Downloads a single file from a cloud URI to a temporary local directory
-   * and returns the local {@link Path}.
-   *
-   * The destination path mirrors the key structure under a plugin-specific
-   * temp directory so repeated calls for the same URI are idempotent.
-   *
-   * <p>Uses {@code nextflow fs cp} under the hood, so any cloud provider
-   * supported by Nextflow (S3, GCS, Azure) is transparently handled.
-   * Authentication is configured via the project's {@code nextflow.config}.
-   *
-   * <p>Uses Groovy named-parameter syntax:
-   * {@code downloadFromS3("s3://my-bucket/path/to/file.vcf.gz")}
-   *
-   * @param cloudUri The cloud URI of the file to download
-   * (e.g., {@code "s3://my-bucket/dir/file.txt"})
-   *
-   * @return A {@link Path} pointing to the downloaded local file
-   * @throws IOException if {@code nextflow fs cp} fails or is not available
-   * @throws InterruptedException if the process is interrupted
-   */
-  public static Path downloadFromS3(
-      final String cloudUri)
-      throws IOException, InterruptedException {
-    return downloadFromS3(new LinkedHashMap<String, Object>(), cloudUri);
-  }
-
-  /**
-   * Length of the URI scheme separator.
-   */
-  private static final int SCHEME_SEPARATOR_LENGTH = 3;
-
-  /**
-   * Downloads a single file from a cloud URI to a temporary local directory
-   * and returns the local {@link Path}.
-   *
-   * See {@link #downloadFromS3(String)} for details.
-   *
-   * @param options Reserved for future use (currently unused)
-   * @param cloudUri The cloud URI of the file to download
-   * @return A {@link Path} pointing to the downloaded local file
-   * @throws IOException if {@code nextflow fs cp} fails or is not available
-   * @throws InterruptedException if the process is interrupted
-   */
-  public static Path downloadFromS3(
-      final LinkedHashMap<String, Object> options,
-      final String cloudUri)
-      throws IOException, InterruptedException {
-    if (cloudUri == null || cloudUri.isEmpty()) {
-      throw new IllegalArgumentException(
-        "The 'cloudUri' parameter is required."
-      );
-    }
-
-    // Derive a stable local destination mirroring the key path:
-    // <tmpdir>/nft-utils-cloud/<key>
-    int schemeEnd = cloudUri.indexOf("://");
-    String withoutScheme;
-    if (schemeEnd >= 0) {
-      withoutScheme = cloudUri.substring(
-        schemeEnd + SCHEME_SEPARATOR_LENGTH
-      );
-    } else {
-      withoutScheme = cloudUri;
-    }
-
-    int firstSlash = withoutScheme.indexOf('/');
-    String relativeKey;
-    if (firstSlash >= 0) {
-      relativeKey = withoutScheme.substring(firstSlash + 1);
-    } else {
-      relativeKey = withoutScheme;
-    }
-
-    Path destFile = Paths.get(
-      System.getProperty("java.io.tmpdir"),
-      "nft-utils-cloud", relativeKey
-    );
-    Path destParent = destFile.getParent();
-    if (destParent != null) {
-      Files.createDirectories(destParent);
-    }
-
-    List<String> cmd = Arrays.asList(
-      "nextflow", "fs", "cp",
-      cloudUri, destFile.toString()
-    );
-    ProcessBuilder pb = new ProcessBuilder(cmd);
-    pb.redirectErrorStream(false);
-    Process process = pb.start();
-    int exitCode = process.waitFor();
-    if (exitCode != 0) {
-      throw new IOException(
-          "nextflow fs cp returned exit code " + exitCode
-          + " when downloading: " + cloudUri);
-    }
-
-    return destFile;
+    ArchiveDownloader.curlAndExtract(urlString, destPath);
   }
 
   /**
    * Download an archive and extract it in the given destination directory.
-   * Dispatches to `curlAndUnzip` for ZIP files and to `curlAndUntar` for
-   * tar archives based on the `compression` parameter.
+   * Dispatches based on the {@code compression} parameter.
    *
    * @param urlString   the URL to fetch
    * @param destPath    directory to extract the archive into
-   * @param compression compression type: zip, tar, or any of the following
-   *                    prefixed with "tar." or "t":
-   *                    gzip, gz, bzip2, bz2, xz, lz4, lzma, lzop, zstd
+   * @param compression compression type
    * @throws IOException on failure or if archive type is unsupported
    */
   public static void curlAndExtract(
@@ -1764,27 +451,38 @@ public final class Methods {
       final String destPath,
       final String compression)
       throws IOException {
-    if (compression == null || compression.isEmpty()) {
-      throw new IllegalArgumentException(
-        "The 'compression' parameter is required."
-      );
-    }
-    String lower = compression.toLowerCase(Locale.ROOT);
-    // Zip is the only clearly defined archive format.
-    // Everything else is assumed to be Tar
-    if (lower.equals("zip")) {
-      curlAndUnzip(urlString, destPath);
-    } else if (lower.equals("tar")) {
-      curlAndUntar(urlString, destPath, null);
-    } else if (lower.startsWith("tar.")) {
-      curlAndUntar(urlString, destPath, compression);
-    } else if (lower.startsWith("t")) {
-      curlAndUntar(urlString, destPath, compression);
-    } else {
-      throw new IllegalArgumentException(
-        "Unsupported compression type: "
-        + compression
-      );
-    }
+    ArchiveDownloader.curlAndExtract(urlString, destPath, compression);
+  }
+
+  /**
+   * Downloads a single file from a cloud URI to a temporary local directory
+   * and returns the local {@link Path}.
+   *
+   * @param cloudUri The cloud URI of the file to download
+   * @return A {@link Path} pointing to the downloaded local file
+   * @throws IOException if {@code nextflow fs cp} fails
+   * @throws InterruptedException if the process is interrupted
+   */
+  public static Path downloadFromS3(
+      final String cloudUri)
+      throws IOException, InterruptedException {
+    return ArchiveDownloader.downloadFromS3(cloudUri);
+  }
+
+  /**
+   * Downloads a single file from a cloud URI to a temporary local directory
+   * and returns the local {@link Path}.
+   *
+   * @param options Reserved for future use (currently unused)
+   * @param cloudUri The cloud URI of the file to download
+   * @return A {@link Path} pointing to the downloaded local file
+   * @throws IOException if {@code nextflow fs cp} fails
+   * @throws InterruptedException if the process is interrupted
+   */
+  public static Path downloadFromS3(
+      final LinkedHashMap<String, Object> options,
+      final String cloudUri)
+      throws IOException, InterruptedException {
+    return ArchiveDownloader.downloadFromS3(options, cloudUri);
   }
 }

--- a/src/main/java/nfcore/nftest/utils/NextflowOutputFilter.java
+++ b/src/main/java/nfcore/nftest/utils/NextflowOutputFilter.java
@@ -179,6 +179,17 @@ public final class NextflowOutputFilter {
 
       filtered = filterLinePattern(filtered, capturedRunName);
 
+      if (additionalPatterns != null && !additionalPatterns.isEmpty()) {
+        for (String pattern : additionalPatterns) {
+          try {
+            filtered = filtered.replaceAll(pattern, "[FILTERED]");
+          } catch (Exception e) {
+            System.err.println("Warning: Invalid regex pattern '" + pattern
+                + "': " + e.getMessage());
+          }
+        }
+      }
+
       if (!filtered.trim().isEmpty()) {
         filteredLines.add(filtered);
       }

--- a/src/main/java/nfcore/nftest/utils/NextflowOutputFilter.java
+++ b/src/main/java/nfcore/nftest/utils/NextflowOutputFilter.java
@@ -1,0 +1,402 @@
+package nfcore.nftest.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility methods for filtering Nextflow stdout/stderr output to remove
+ * variable content that makes test snapshots unstable.
+ */
+public final class NextflowOutputFilter {
+
+  /**
+   * Prevents instantiation of this utility class.
+   */
+  private NextflowOutputFilter() {
+  }
+
+  /**
+   * Filters Nextflow stdout/stderr output to remove variable content that makes
+   * snapshots unstable.
+   *
+   * @param output The stdout or stderr output (String or List) to filter
+   * @return The filtered output as a List&lt;String&gt; with unstable patterns
+   *     removed
+   */
+  public static List<String> filterNextflowOutput(final Object output) {
+    return filterNextflowOutput(output, null, true, false, null, null);
+  }
+
+  /**
+   * Filters Nextflow stdout/stderr output with optional sorting.
+   *
+   * @param output The stdout or stderr output (String or List) to filter
+   * @param sorted Whether to sort the output lines alphabetically
+   * @return The filtered output as a List&lt;String&gt; with unstable patterns
+   *     removed
+   */
+  public static List<String> filterNextflowOutput(
+      final Object output,
+      final boolean sorted) {
+    return filterNextflowOutput(output, null, sorted, false, null, null);
+  }
+
+  /**
+   * Filters Nextflow stdout/stderr output with optional sorting and ANSI code
+   * handling.
+   *
+   * @param output   The stdout or stderr output (String or List) to filter
+   * @param sorted   Whether to sort the output lines alphabetically
+   * @param keepAnsi Whether to keep ANSI escape codes (colors, formatting)
+   * @return The filtered output as a List&lt;String&gt; with unstable patterns
+   *     removed
+   */
+  public static List<String> filterNextflowOutput(
+      final Object output,
+      final boolean sorted,
+      final boolean keepAnsi) {
+    return filterNextflowOutput(output, null, sorted, keepAnsi, null, null);
+  }
+
+  /**
+   * Filters Nextflow stdout/stderr output with custom patterns.
+   *
+   * @param output             The stdout or stderr output (String or List) to
+   *                           filter
+   * @param additionalPatterns List of additional regex patterns to remove
+   * @return The filtered output as a List&lt;String&gt; with unstable patterns
+   *     removed
+   */
+  public static List<String> filterNextflowOutput(
+      final Object output,
+      final List<String> additionalPatterns) {
+    return filterNextflowOutput(
+      output, additionalPatterns,
+      true, false, null, null
+    );
+  }
+
+  /**
+   * Filters Nextflow stdout/stderr output with custom patterns, optional
+   * sorting, and ANSI code handling.
+   *
+   * @param output             The stdout or stderr output (String or List) to
+   *                           filter
+   * @param additionalPatterns List of additional regex patterns to remove
+   * @param sorted             Whether to sort the output lines alphabetically
+   * @param keepAnsi           Whether to keep ANSI escape codes
+   * @param ignore             List of strings to filter out
+   * @param include            List of strings to include
+   * @return The filtered output as a List&lt;String&gt; with unstable patterns
+   *     removed
+   */
+  public static List<String> filterNextflowOutput(
+      final Object output,
+      final List<String> additionalPatterns,
+      final boolean sorted,
+      final boolean keepAnsi,
+      final List<String> ignore,
+      final List<String> include) {
+    if (output == null) {
+      return new ArrayList<>();
+    }
+
+    List<String> outputLines;
+    if (output instanceof List) {
+      List<?> outputList = (List<?>) output;
+      if (outputList.isEmpty()) {
+        return new ArrayList<>();
+      }
+      outputLines = outputList.stream()
+          .map(Object::toString)
+          .collect(Collectors.toList());
+    } else if (output instanceof String) {
+      String outputString = (String) output;
+      if (outputString.isEmpty()) {
+        return new ArrayList<>();
+      }
+      outputLines = Arrays.asList(outputString.split("\n"));
+    } else {
+      String outputString = output.toString();
+      outputLines = Arrays.asList(outputString.split("\n"));
+    }
+
+    List<String> filteredLines = new ArrayList<>();
+    String capturedRunName = null;
+
+    for (String line : outputLines) {
+      String filtered = line;
+
+      if (ignore != null && !ignore.isEmpty()) {
+        boolean shouldIgnore = false;
+        for (String ignoreString : ignore) {
+          if (filtered.contains(ignoreString)) {
+            shouldIgnore = true;
+            break;
+          }
+        }
+        if (shouldIgnore) {
+          continue;
+        }
+      }
+
+      if (include != null && !include.isEmpty()) {
+        boolean shouldInclude = false;
+        for (String includeString : include) {
+          if (filtered.contains(includeString)) {
+            shouldInclude = true;
+            break;
+          }
+        }
+        if (!shouldInclude) {
+          continue;
+        }
+      }
+
+      if (!keepAnsi) {
+        filtered = filtered.replaceAll(
+          "\\x1B\\[[0-9;]*[A-Za-z]", "");
+      }
+
+      if (
+          capturedRunName == null
+          && filtered.contains("Launching")
+          && filtered.contains("[")
+          && filtered.contains("]")) {
+        java.util.regex.Pattern runNamePattern =
+          java.util.regex.Pattern.compile("\\[([^\\]]+)\\]");
+        java.util.regex.Matcher matcher = runNamePattern.matcher(filtered);
+        if (matcher.find()) {
+          capturedRunName = matcher.group(1);
+        }
+      }
+
+      filtered = filterLinePattern(filtered, capturedRunName);
+
+      if (!filtered.trim().isEmpty()) {
+        filteredLines.add(filtered);
+      }
+    }
+
+    if (sorted) {
+      List<String> sortableLines = new ArrayList<>();
+      List<String> preserveOrderLines = new ArrayList<>();
+
+      for (String line : filteredLines) {
+        if (line.contains("Staging foreign file")
+            || line.contains("Submitted process")
+            || line.startsWith("Creating env using conda:")
+            || line.startsWith("Pulling Singularity image")
+            || line.startsWith("ERROR ~")
+            || line.startsWith("WARN:")
+            || (
+              line.contains("Check ")
+              && line.contains(" file for details")
+            )) {
+          sortableLines.add(line);
+        } else {
+          preserveOrderLines.add(line);
+        }
+      }
+
+      Collections.sort(sortableLines);
+
+      List<String> combinedLines = new ArrayList<>();
+      combinedLines.addAll(preserveOrderLines);
+      combinedLines.addAll(sortableLines);
+
+      List<String> uniqueLines = new ArrayList<>();
+      String lastLine = null;
+      for (String line : combinedLines) {
+        if (!line.equals(lastLine)) {
+          uniqueLines.add(line);
+          lastLine = line;
+        }
+      }
+      filteredLines = uniqueLines;
+    }
+
+    return filteredLines;
+  }
+
+  /**
+   * Filters Nextflow output using Groovy's named parameter syntax.
+   *
+   * @param options LinkedHashMap of named options (Groovy named params)
+   * @param output  The stdout or stderr output to filter
+   * @return The filtered output as a List&lt;String&gt;
+   */
+  public static List<String> filterNextflowOutput(
+      final LinkedHashMap<String, Object> options,
+      final Object output) {
+    final Map<String, Object> optionsFixed;
+    if (options == null) {
+      optionsFixed = new HashMap<>();
+    } else {
+      optionsFixed = options;
+    }
+
+    List<String> additionalPatterns = (List<String>) optionsFixed
+      .get("additionalPatterns");
+    Boolean sorted = (Boolean) optionsFixed.get("sorted");
+    Boolean keepAnsi = (Boolean) optionsFixed.get("keepAnsi");
+    List<String> ignore = (List<String>) optionsFixed.get("ignore");
+    List<String> include = (List<String>) optionsFixed.get("include");
+
+    if (sorted == null) {
+      sorted = true;
+    }
+    if (keepAnsi == null) {
+      keepAnsi = false;
+    }
+    return filterNextflowOutput(
+      output, additionalPatterns,
+      sorted, keepAnsi, ignore, include
+    );
+  }
+
+  /**
+   * Sanitizes a Nextflow output line by replacing non-deterministic values with
+   * stable placeholders.
+   *
+   * @param line The output line to sanitize.
+   * @param capturedRunName The run name captured from the Nextflow launching
+   *     line, or {@code null} if no run name was captured.
+   * @return The sanitized output line.
+   */
+  public static String filterLinePattern(
+      final String line,
+      final String capturedRunName) {
+    String filtered = line;
+
+    String userName = System.getProperty("user.name");
+    if (userName != null && !userName.isEmpty()) {
+      filtered = filtered.replaceAll(
+        "(userName\\s*:\\s*)" + java.util.regex.Pattern.quote(userName),
+        "$1[USER]");
+    }
+
+    filtered = filtered.replaceAll(
+        "\\d{4}-\\d{2}-\\d{2}[T\\s_]\\d{2}[:-]\\d{2}[:-]\\d{2}"
+        + "(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})?",
+        "[TIMESTAMP]");
+    filtered = filtered.replaceAll(
+      "\\d{2}/\\d{2}/\\d{4}\\s+\\d{2}:\\d{2}:\\d{2}",
+      "[TIMESTAMP]");
+
+    filtered = filtered.replaceAll(
+      "\\[[0-9a-f]{2}/[0-9a-f]{6}\\]",
+      "[NXF_HASH]");
+
+    filtered = filtered.replaceAll(
+      "\\b[0-9a-f]{30,32}\\b",
+      "[NFT_HASH]");
+
+    filtered = filtered.replaceAll(
+      "revision: [0-9a-f]{10}",
+      "revision: [REVISION]");
+
+    filtered = filtered.replaceAll(
+      ".*Nextflow\\s+\\d+\\.\\d+\\.\\d+.*is available.*",
+      "");
+    filtered = filtered.replaceAll(
+      ".*Please consider updating your version.*",
+      "");
+
+    filtered = filterAbsolutePaths(filtered);
+
+    if (capturedRunName != null) {
+      filtered = filtered.replace(
+        "[" + capturedRunName + "]",
+        "[RUN_NAME]");
+      filtered = filtered.replace(
+        capturedRunName,
+        "[RUN_NAME]");
+    }
+
+    filtered = filtered.replaceAll(".*containerEngine.*", "");
+
+    filtered = filtered.replaceAll("apptainer", "[CONTAINER]");
+    filtered = filtered.replaceAll("charliecloud", "[CONTAINER]");
+    filtered = filtered.replaceAll("conda", "[CONTAINER]");
+    filtered = filtered.replaceAll("docker", "[CONTAINER]");
+    filtered = filtered.replaceAll("mamba", "[CONTAINER]");
+    filtered = filtered.replaceAll("podman", "[CONTAINER]");
+    filtered = filtered.replaceAll("shifter", "[CONTAINER]");
+    filtered = filtered.replaceAll("singularity", "[CONTAINER]");
+    filtered = filtered.replaceAll("wave", "[CONTAINER]");
+
+    filtered = filtered.replaceAll(
+      "(nf-core/[^\\s]+\\s+)\\d+\\.\\d+(?:\\.\\d+)?[a-zA-Z]*",
+      "$1[VERSION]");
+
+    filtered = filtered.replaceAll(
+      "N E X T F L O W  ~  version \\d+\\.\\d+\\.\\d+(-edge)?",
+      "N E X T F L O W  ~  version [VERSION]");
+
+    return filtered;
+  }
+
+  /**
+   * Filters absolute paths in the given text and replaces them with [PATH]
+   * placeholder.
+   *
+   * @param text The text to filter
+   * @return The filtered text with various directory paths replaced with
+   *     [PATH]
+   */
+  static String filterAbsolutePaths(final String text) {
+    String filtered = text;
+
+    List<String> pathsToReplace = new ArrayList<>();
+
+    String workingDir = System.getProperty("user.dir");
+    if (workingDir != null) {
+      pathsToReplace.add(workingDir);
+    }
+
+    String[] envVars = {
+        "HOME",
+        "NFT_WORKDIR",
+        "NXF_CACHE_DIR",
+        "NXF_CONDA_CACHEDIR",
+        "NXF_HOME",
+        "NXF_SINGULARITY_CACHEDIR",
+        "NXF_SINGULARITY_LIBRARYDIR",
+        "NXF_TEMP",
+        "NXF_WORK"
+    };
+
+    for (String envVar : envVars) {
+      String envValue = System.getenv(envVar);
+      if (envValue != null && !envValue.isEmpty() && !envValue.equals("~")) {
+        pathsToReplace.add(envValue);
+      }
+    }
+
+    String nxfHome = System.getenv("NXF_HOME");
+    if (nxfHome == null || nxfHome.isEmpty()) {
+      String home = System.getProperty("user.home");
+      if (home != null && !home.isEmpty() && !home.equals("~")) {
+        pathsToReplace.add(home + "/.nextflow");
+      }
+    }
+
+    pathsToReplace = pathsToReplace.stream()
+        .distinct()
+        .sorted((a, b) -> Integer.compare(b.length(), a.length()))
+        .collect(Collectors.toList());
+
+    for (String path : pathsToReplace) {
+      filtered = filtered.replace(path, "[PATH]");
+    }
+
+    return filtered;
+  }
+}

--- a/src/main/java/nfcore/nftest/utils/NfCoreUtils.java
+++ b/src/main/java/nfcore/nftest/utils/NfCoreUtils.java
@@ -176,11 +176,6 @@ public final class NfCoreUtils {
   }
 
   /**
-  * Bit mask used to convert a signed byte to its unsigned representation.
-  */
-  private static final int BYTE_MASK = 0xff;
-
-  /**
    * Create a cache key for a module based on its parameters.
    *
    * @param name The module name
@@ -201,20 +196,7 @@ public final class NfCoreUtils {
     }
 
     try {
-      java.security.MessageDigest md = java.security.MessageDigest
-        .getInstance("MD5");
-      byte[] messageDigest = md.digest(
-        key.toString().getBytes(StandardCharsets.UTF_8)
-      );
-      StringBuilder hexString = new StringBuilder();
-      for (byte b : messageDigest) {
-        String hex = Integer.toHexString(BYTE_MASK & b);
-        if (hex.length() == 1) {
-          hexString.append('0');
-        }
-        hexString.append(hex);
-      }
-      return hexString.toString();
+      return HashUtils.md5Hex(key.toString());
     } catch (java.security.NoSuchAlgorithmException e) {
       throw new RuntimeException(
         "MD5 algorithm not available on this system", e

--- a/src/main/java/nfcore/nftest/utils/NfCoreUtils.java
+++ b/src/main/java/nfcore/nftest/utils/NfCoreUtils.java
@@ -81,27 +81,36 @@ public final class NfCoreUtils {
     }
 
     for (Object moduleObj : modules) {
-      if (moduleObj instanceof String) {
-        installModule(libDir, (String) moduleObj, null, null);
-      } else if (
-          moduleObj instanceof LinkedHashMap
-          || moduleObj instanceof Map) {
-        Map<String, String> moduleMap = (Map<String, String>) moduleObj;
-        String name = moduleMap.get("name");
-        String sha = moduleMap.get("sha");
-        String remote = moduleMap.get("remote");
+      try {
+        if (moduleObj instanceof String) {
+          installModule(
+            libDir, (String) moduleObj, null, null);
+        } else if (
+            moduleObj instanceof LinkedHashMap
+            || moduleObj instanceof Map) {
+          @SuppressWarnings("unchecked")
+          Map<String, String> moduleMap =
+            (Map<String, String>) moduleObj;
+          String name = moduleMap.get("name");
+          String sha = moduleMap.get("sha");
+          String remote = moduleMap.get("remote");
 
-        if (name == null || name.isEmpty()) {
-          throw new IllegalArgumentException("Module name is required");
+          if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException(
+              "Module name is required"
+            );
+          }
+
+          installModule(libDir, name, sha, remote);
+        } else {
+          throw new RuntimeException(
+            "Unsupported module type: "
+            + moduleObj.getClass().getSimpleName()
+            + ". Expected String or Map."
+          );
         }
-
-        installModule(libDir, name, sha, remote);
-      } else {
-        throw new RuntimeException(
-          "Unsupported module type: "
-          + moduleObj.getClass().getSimpleName()
-          + ". Expected String or Map."
-        );
+      } catch (IOException e) {
+        System.err.println(e.getMessage());
       }
     }
   }
@@ -113,66 +122,60 @@ public final class NfCoreUtils {
    * @param name The module name (required)
    * @param sha The SHA hash (optional)
    * @param remote The remote repository (optional)
+   * @throws IOException if the install command fails or is interrupted
    */
   private static void installModule(
       final String libDir,
       final String name,
       final String sha,
       final String remote
-    ) {
-    try {
-      // Create a cache key based on module parameters
-      String cacheKey = createModuleCacheKey(name, sha, remote);
-      File stateFile = new File(libDir + "/state/" + cacheKey + ".installed");
+    ) throws IOException {
+    String cacheKey = createModuleCacheKey(name, sha, remote);
+    File stateFile = new File(
+      libDir + "/state/" + cacheKey + ".installed");
 
-      // Check if module is already installed
-      if (stateFile.exists()) {
-        System.out.println("Module already installed (cached): " + name);
-        return;
-      }
-
-      StringBuilder command = new StringBuilder(
-        "cd " + libDir + " && nf-core --verbose modules"
-      );
-
-      if (remote != null && !remote.isEmpty()) {
-        command.append(" --git-remote ").append(remote);
-      }
-
-      command.append(" install ").append(name);
-
-      if (sha != null && !sha.isEmpty()) {
-        command.append(" --sha ").append(sha);
-      }
-
-      ProcessBuilder processBuilder = new ProcessBuilder(
-        "bash", "-c", command.toString()
-      );
-      Utils.ProcessResult result = Utils.runProcess(processBuilder);
-
-      // Spit out nf-core tools stderr if install fails
-      if (result.getExitCode() != 0) {
-        System.err.println(
-          "Error installing module " + name
-          + ": exit code " + result.getExitCode() + "\n"
-        );
-        System.out.println("Installation command: \n" + command.toString());
-        System.err.println("nf-core tools output: \n");
-        System.err.println(result.getStderr());
-      } else {
-        System.out.println("Successfully installed module: " + name);
-        // Write state file to mark module as installed
-        writeModuleStateFile(stateFile);
-      }
-    } catch (IOException | InterruptedException e) {
-      System.err.println(
-        "Error installing module "
-        + name + ": " + e.getMessage()
-      );
-      if (e instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-      }
+    if (stateFile.exists()) {
+      System.out.println(
+        "Module already installed (cached): " + name);
+      return;
     }
+
+    StringBuilder command = new StringBuilder(
+      "cd " + libDir + " && nf-core --verbose modules"
+    );
+
+    if (remote != null && !remote.isEmpty()) {
+      command.append(" --git-remote ").append(remote);
+    }
+
+    command.append(" install ").append(name);
+
+    if (sha != null && !sha.isEmpty()) {
+      command.append(" --sha ").append(sha);
+    }
+
+    ProcessBuilder processBuilder = new ProcessBuilder(
+      "bash", "-c", command.toString()
+    );
+    Utils.ProcessResult result;
+    try {
+      result = Utils.runProcess(processBuilder);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException(
+        "Interrupted installing module " + name, e
+      );
+    }
+
+    if (result.getExitCode() != 0) {
+      throw new IOException(
+        "Failed to install module " + name
+        + ": exit code " + result.getExitCode() + "\n"
+        + result.getStderr()
+      );
+    }
+    System.out.println("Successfully installed module: " + name);
+    writeModuleStateFile(stateFile);
   }
 
   /**

--- a/src/main/java/nfcore/nftest/utils/OutputSanitizer.java
+++ b/src/main/java/nfcore/nftest/utils/OutputSanitizer.java
@@ -18,7 +18,8 @@ import java.util.stream.Collectors;
 public final class OutputSanitizer {
 
   /** Default number of decimal places for CSV double values. */
-  private static final int DEFAULT_CSV_DOUBLE_DIGITS = 6;
+  private static final int DEFAULT_CSV_DOUBLE_DIGITS =
+    CsvUtils.DEFAULT_DOUBLE_DIGITS;
 
   /**
    * Prevents instantiation of this utility class.

--- a/src/main/java/nfcore/nftest/utils/OutputSanitizer.java
+++ b/src/main/java/nfcore/nftest/utils/OutputSanitizer.java
@@ -111,8 +111,6 @@ public final class OutputSanitizer {
       final HashMap<String, Object> options,
       final TreeMap<String, Object> channel) {
     String className = channel.getClass().getName();
-    // Can't do valid type checking here because
-    // the channels type is not exposed from nf-test
     if (!className.equals("com.askimed.nf.test.lang.channels.Channels")) {
       throw new RuntimeException(
         "sanitizeOutput only supports channels as input, "
@@ -120,50 +118,21 @@ public final class OutputSanitizer {
       );
     }
 
-    // Fetch options
-    List<String> unstableKeys =
-      (List<String>) options.getOrDefault("unstableKeys", List.of());
-
-    List<String> ignoreKeys =
-      (List<String>) options.getOrDefault("ignoreKeys", List.of());
-
-    List<String> unstablePatterns =
-      (List<String>) options.getOrDefault("unstablePatterns", List.of());
-
-    List<String> ignorePatterns =
-      (List<String>) options.getOrDefault("ignorePatterns", List.of());
-
-    List<String> readsMD5Keys =
-      (List<String>) options.getOrDefault("readsMD5Keys", List.of());
-
-    List<String> variantsMD5Keys =
-      (List<String>) options.getOrDefault("variantsMD5Keys", List.of());
-
-    List<String> csvMD5Keys =
-      (List<String>) options.getOrDefault("csvMD5Keys", List.of());
-
-    String referenceFasta = (String) options.getOrDefault("referenceFasta", "");
-    int csvDoubleDigits = (int) options.getOrDefault(
-      "csvDoubleDigits", DEFAULT_CSV_DOUBLE_DIGITS
-    );
-
-    if (csvDoubleDigits < 0) {
-      throw new IllegalArgumentException(
-        "csvDoubleDigits must be greater than or equal to zero"
-      );
-    }
+    SanitizeOptions opts = new SanitizeOptions(options);
 
     validateKeyUsage(
-      unstableKeys, ignoreKeys, readsMD5Keys,
-      variantsMD5Keys, csvMD5Keys
+      opts.getUnstableKeys(), opts.getIgnoreKeys(),
+      opts.getReadsMD5Keys(), opts.getVariantsMD5Keys(),
+      opts.getCsvMD5Keys()
     );
 
-    validateKeysInChannel(unstableKeys, channel);
-    validateKeysInChannel(ignoreKeys, channel);
-    validateKeysInChannel(readsMD5Keys, channel);
-    validateKeysInChannel(variantsMD5Keys, channel);
-    validateKeysInChannel(csvMD5Keys, channel);
+    validateKeysInChannel(opts.getUnstableKeys(), channel);
+    validateKeysInChannel(opts.getIgnoreKeys(), channel);
+    validateKeysInChannel(opts.getReadsMD5Keys(), channel);
+    validateKeysInChannel(opts.getVariantsMD5Keys(), channel);
+    validateKeysInChannel(opts.getCsvMD5Keys(), channel);
 
+    List<String> readsMD5Keys = opts.getReadsMD5Keys();
     if (!readsMD5Keys.isEmpty() && !BamUtils.isNftBamAvailable()) {
       System.err.println(
         "WARNING: A compatible version of nft-bam is not available. "
@@ -172,6 +141,7 @@ public final class OutputSanitizer {
       );
       readsMD5Keys = List.of();
     }
+    List<String> variantsMD5Keys = opts.getVariantsMD5Keys();
     if (!variantsMD5Keys.isEmpty() && !VcfUtils.isNftVcfAvailable()) {
       System.err.println(
         "WARNING: A compatible version of nft-vcf is not available. "
@@ -187,26 +157,168 @@ public final class OutputSanitizer {
       String key = entry.getKey();
       Object value = entry.getValue();
       if (key.matches("^\\d+$") && channelSize > 1) {
-        // Skip numeric keys if there is more than one entry in the channel
         continue;
       }
-      if (ignoreKeys.contains(key)) {
+      if (opts.getIgnoreKeys().contains(key)) {
         continue;
       }
 
-      if (unstableKeys.contains(key)) {
+      if (opts.getUnstableKeys().contains(key)) {
         output.put(key, fixUnstable(value));
       } else if (readsMD5Keys.contains(key)) {
-        output.put(key, BamUtils.bamMD5(value, referenceFasta));
+        output.put(key, BamUtils.bamMD5(
+          value, opts.getReferenceFasta()));
       } else if (variantsMD5Keys.contains(key)) {
         output.put(key, VcfUtils.vcfMD5(value));
-      } else if (csvMD5Keys.contains(key)) {
-        output.put(key, CsvUtils.csvMD5(value, csvDoubleDigits));
+      } else if (opts.getCsvMD5Keys().contains(key)) {
+        output.put(key, CsvUtils.csvMD5(
+          value, opts.getCsvDoubleDigits()));
       } else {
-        output.put(key, checkPattern(value, unstablePatterns, ignorePatterns));
+        output.put(key, checkPattern(
+          value, opts.getUnstablePatterns(),
+          opts.getIgnorePatterns()));
       }
     }
     return output;
+  }
+
+  /**
+   * Holds the parsed and validated sanitization options.
+   */
+  private static final class SanitizeOptions {
+    /** Keys whose values should be replaced with file names. */
+    private final List<String> unstableKeys;
+    /** Keys to exclude from output entirely. */
+    private final List<String> ignoreKeys;
+    /** Glob patterns matching unstable file paths. */
+    private final List<String> unstablePatterns;
+    /** Glob patterns matching values to ignore. */
+    private final List<String> ignorePatterns;
+    /** Keys whose BAM/SAM/CRAM values should be hashed. */
+    private final List<String> readsMD5Keys;
+    /** Keys whose VCF/BCF values should be hashed. */
+    private final List<String> variantsMD5Keys;
+    /** Keys whose CSV/TSV values should be hashed. */
+    private final List<String> csvMD5Keys;
+    /** Reference FASTA path for BAM MD5 calculation. */
+    private final String referenceFasta;
+    /** Decimal places for CSV floating-point normalization. */
+    private final int csvDoubleDigits;
+
+    /**
+     * Creates sanitization options from a map.
+     *
+     * @param options The options map from Groovy named params.
+     */
+    @SuppressWarnings("unchecked")
+    SanitizeOptions(final HashMap<String, Object> options) {
+      this.unstableKeys = (List<String>) options
+        .getOrDefault("unstableKeys", List.of());
+      this.ignoreKeys = (List<String>) options
+        .getOrDefault("ignoreKeys", List.of());
+      this.unstablePatterns = (List<String>) options
+        .getOrDefault("unstablePatterns", List.of());
+      this.ignorePatterns = (List<String>) options
+        .getOrDefault("ignorePatterns", List.of());
+      this.readsMD5Keys = (List<String>) options
+        .getOrDefault("readsMD5Keys", List.of());
+      this.variantsMD5Keys = (List<String>) options
+        .getOrDefault("variantsMD5Keys", List.of());
+      this.csvMD5Keys = (List<String>) options
+        .getOrDefault("csvMD5Keys", List.of());
+      this.referenceFasta = (String) options
+        .getOrDefault("referenceFasta", "");
+      this.csvDoubleDigits = (int) options
+        .getOrDefault(
+          "csvDoubleDigits", DEFAULT_CSV_DOUBLE_DIGITS);
+
+      if (this.csvDoubleDigits < 0) {
+        throw new IllegalArgumentException(
+          "csvDoubleDigits must be >= 0"
+        );
+      }
+    }
+
+    /**
+     * Returns keys whose values should be replaced with file names.
+     *
+     * @return the unstable keys
+     */
+    List<String> getUnstableKeys() {
+      return unstableKeys;
+    }
+
+    /**
+     * Returns keys to exclude from output entirely.
+     *
+     * @return the ignore keys
+     */
+    List<String> getIgnoreKeys() {
+      return ignoreKeys;
+    }
+
+    /**
+     * Returns glob patterns matching unstable file paths.
+     *
+     * @return the unstable patterns
+     */
+    List<String> getUnstablePatterns() {
+      return unstablePatterns;
+    }
+
+    /**
+     * Returns glob patterns matching values to ignore.
+     *
+     * @return the ignore patterns
+     */
+    List<String> getIgnorePatterns() {
+      return ignorePatterns;
+    }
+
+    /**
+     * Returns keys whose BAM/SAM/CRAM values should be hashed.
+     *
+     * @return the reads MD5 keys
+     */
+    List<String> getReadsMD5Keys() {
+      return readsMD5Keys;
+    }
+
+    /**
+     * Returns keys whose VCF/BCF values should be hashed.
+     *
+     * @return the variants MD5 keys
+     */
+    List<String> getVariantsMD5Keys() {
+      return variantsMD5Keys;
+    }
+
+    /**
+     * Returns keys whose CSV/TSV values should be hashed.
+     *
+     * @return the CSV MD5 keys
+     */
+    List<String> getCsvMD5Keys() {
+      return csvMD5Keys;
+    }
+
+    /**
+     * Returns the reference FASTA path for BAM MD5.
+     *
+     * @return the reference FASTA path
+     */
+    String getReferenceFasta() {
+      return referenceFasta;
+    }
+
+    /**
+     * Returns decimal places for CSV float normalization.
+     *
+     * @return the number of decimal digits
+     */
+    int getCsvDoubleDigits() {
+      return csvDoubleDigits;
+    }
   }
 
   /**

--- a/src/main/java/nfcore/nftest/utils/YamlUtils.java
+++ b/src/main/java/nfcore/nftest/utils/YamlUtils.java
@@ -1,0 +1,194 @@
+package nfcore.nftest.utils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Utility methods for reading and manipulating YAML files.
+ */
+public final class YamlUtils {
+
+  /**
+   * Prevents instantiation of this utility class.
+   */
+  private YamlUtils() {
+  }
+
+  /**
+   * Reads a Version YAML file and returns its contents as a nested map.
+   *
+   * @param filePath The path to the YAML file to read.
+   * @return A nested map containing the YAML data, or {@code null} if the file
+   *     cannot be read.
+   */
+  public static Map<String, Map<String, Object>> readYamlFile(
+      final String filePath) {
+    Yaml yaml = new Yaml();
+    try (BufferedReader reader = Files.newBufferedReader(
+        Paths.get(filePath),
+        StandardCharsets.UTF_8)) {
+      Map<String, Map<String, Object>> data = yaml.load(reader);
+      return data;
+    } catch (IOException e) {
+      System.err.println("Error reading YAML file: " + e.getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * Resolves a file path or wildcard pattern to a list of matching file paths.
+   *
+   * @param pathPattern The file path or wildcard pattern to resolve.
+   * @return A sorted list of matching absolute file paths.
+   * @throws IOException If the parent directory does not exist, no files match
+   *     the pattern, or an error occurs while accessing the directory.
+   */
+  static List<String> resolveWildcardPaths(
+      final String pathPattern)
+      throws IOException {
+    if (!pathPattern.contains("*") && !pathPattern.contains("?")) {
+      return Arrays.asList(pathPattern);
+    }
+
+    Path pattern = Paths.get(pathPattern);
+    Path parent = pattern.getParent();
+    Path fileNamePath = pattern.getFileName();
+    if (fileNamePath == null) {
+      throw new IOException(
+        "Invalid path pattern: " + pathPattern
+      );
+    }
+    String fileName = fileNamePath.toString();
+
+    if (parent == null) {
+      parent = Paths.get(".");
+    }
+
+    if (!Files.exists(parent) || !Files.isDirectory(parent)) {
+      throw new IOException(
+        "Parent directory does not exist: "
+        + parent
+      );
+    }
+
+    PathMatcher matcher = FileSystems
+      .getDefault()
+      .getPathMatcher("glob:" + fileName);
+
+    try {
+      List<String> matchingFiles = Files.list(parent)
+          .filter(Files::isRegularFile)
+          .filter(path -> matcher.matches(path.getFileName()))
+          .sorted()
+          .map(path -> path.toAbsolutePath().toString())
+          .collect(Collectors.toList());
+
+      if (matchingFiles.isEmpty()) {
+        throw new IOException(
+          "No files found matching pattern: "
+          + pathPattern
+        );
+      }
+
+      return matchingFiles;
+    } catch (IOException e) {
+      throw new IOException(
+        "Error resolving wildcard pattern "
+        + pathPattern + ": " + e.getMessage()
+      );
+    }
+  }
+
+  /**
+   * Removes the Nextflow version entry from the Workflow entry in the
+   * specified Version YAML file.
+   *
+   * @param versionFile The YAML file path or wildcard pattern to process.
+   * @return A map containing the YAML data with the Nextflow version removed.
+   */
+  public static Map<String, Map<String, Object>> removeNextflowVersion(
+      final CharSequence versionFile) {
+    return removeFromYamlMap(versionFile, "Workflow", "Nextflow");
+  }
+
+  /**
+   * Removes an entry from a YAML map and merges the processed results from all
+   * files matching the specified path or wildcard pattern.
+   *
+   * @param versionFile The YAML file path or wildcard pattern to process.
+   * @param key1 The top-level key from which to remove an entry.
+   * @param key2 The nested key to remove, or {@code null} or empty to remove
+   *     the entire {@code key1} entry.
+   * @return A merged map containing the processed YAML data.
+   */
+  public static Map<String, Map<String, Object>> removeFromYamlMap(
+      final CharSequence versionFile,
+      final String key1,
+      final String key2) {
+    String yamlFilePattern = versionFile.toString();
+    Map<String, Map<String, Object>> mergedResult = new TreeMap<>();
+
+    try {
+      List<String> yamlFilePaths = resolveWildcardPaths(yamlFilePattern);
+
+      for (String yamlFilePath : yamlFilePaths) {
+        Map<String, Map<String, Object>> yamlData = readYamlFile(yamlFilePath);
+
+        if (yamlData != null) {
+          if (yamlData.containsKey(key1)) {
+            if (key2 == null || key2.isEmpty()) {
+              yamlData.remove(key1);
+            } else {
+              yamlData.get(key1).remove(key2);
+            }
+          }
+
+          for (
+              Map.Entry<String, Map<String, Object>> entry
+              : yamlData.entrySet()) {
+            String key = entry.getKey();
+            Map<String, Object> value = entry.getValue();
+
+            if (mergedResult.containsKey(key)) {
+              mergedResult.get(key).putAll(value);
+            } else {
+              mergedResult.put(key, new TreeMap<>(value));
+            }
+          }
+        }
+      }
+    } catch (IOException e) {
+      System.err.println(
+        "Error resolving file path pattern: " + e.getMessage()
+      );
+      return null;
+    }
+
+    return mergedResult;
+  }
+
+  /**
+   * Removes the specified key from a YAML map using default options.
+   *
+   * @param versionFile The YAML content containing the map to modify.
+   * @param key1 The key to remove from the YAML map.
+   * @return A map containing the updated YAML data.
+   */
+  public static Map<String, Map<String, Object>> removeFromYamlMap(
+      final CharSequence versionFile,
+      final String key1) {
+    return removeFromYamlMap(versionFile, key1, null);
+  }
+}


### PR DESCRIPTION
## Summary

Methods.java was 1,790 lines mixing 7+ concerns. This PR breaks it into 5 utility classes, extracts a typed options model from OutputSanitizer, and fixes three code-quality blockers from review.

### New classes
| Class | Lines | Responsibility |
|---|---|---|
| `HashUtils` | 82 | Single MD5 implementation (was duplicated 3x) |
| `YamlUtils` | 194 | YAML reading and key manipulation |
| `ArchiveDownloader` | 460 | curl/zip/tar extraction and S3 downloads |
| `FileTraversalUtils` | 443 | Directory walking, file collection, path resolution |
| `NextflowOutputFilter` | 402 | Nextflow output line filtering and sanitization |

### Changes to existing files
- **Methods.java**: 1,790 → 488 lines. Delegation facade with section dividers. All public signatures preserved.
- **OutputSanitizer.java**: Extracted `SanitizeOptions` inner class. Moves 9 `getOrDefault` calls and validation out of the 100-line `sanitizeOutput` method.
- **NfCoreUtils.java**: Removed duplicate MD5, uses `HashUtils.md5Hex()`. `installModule` now throws `IOException` on failure instead of swallowing it.
- **CsvUtils.java**: Removed duplicate MD5, uses `HashUtils.md5Hex()`. Owns `DEFAULT_DOUBLE_DIGITS` as single source of truth.
- **ArchiveDownloader.java**: `curlAndUntar` and `curlAndUnzip` now throw `IOException` on failure instead of logging and returning silently.

### Also fixed
- Deleted duplicate `filterNextflowOutput(Object, Map)` adapter (identical to the `LinkedHashMap` variant)
- Fixed raw types (`List` → `List<?>` / `List<String>`) in public API signatures
- Consolidated `DEFAULT_CSV_DOUBLE_DIGITS` (was duplicated in Methods and OutputSanitizer)

### Deferred
- Consolidate two MD5 implementations within `HashUtils`
- Decompose `NextflowOutputFilter.filterNextflowOutput` 127-line method
- Extract shared `buildMatchers(List<String>)` helper (duplicated 3x)

### Verification
- 24/24 unit tests pass
- Checkstyle, PMD, SpotBugs: clean

Generated via opencode and mistral-ai
Verified by @maxulysse